### PR TITLE
Added additional subfields to last_message field of the channel

### DIFF
--- a/twake/backend/core/src/Twake/Discussion/Services/MessageSystem.php
+++ b/twake/backend/core/src/Twake/Discussion/Services/MessageSystem.php
@@ -580,6 +580,7 @@ class MessageSystem
 
         $title = "";
         $text = $this->buildShortText($message);
+        $body = $text; // we need original body just in case text gets updated further on
         if ($channel->getData()["is_direct"]) {
             $title = $senderName . " in " . $channel->getData()["company_name"];
         }else{
@@ -622,8 +623,10 @@ class MessageSystem
                 "channel_id" => $messageArray["channel_id"],
                 "date" => $messageArray["creation_date"] * 1000,
                 "sender" => $messageArray["sender"],
-                "title" => $title,
-                "text" => $text
+                "sender_name" => $senderName, // username, because it's not convenient to make request to find out username by id
+                "title" => $title, 
+                "text" => $text,
+                "body" => $body // original body of the message without sender
             ];
 
             if($messageArray["message_type"] != 2){ //Ignore system messages

--- a/twake/backend/node/src/services/channels/entities/channel-activity.ts
+++ b/twake/backend/node/src/services/channels/entities/channel-activity.ts
@@ -30,6 +30,7 @@ export class ChannelActivity {
   last_message: {
     date: number;
     sender: string;
+    sender_name: string;
     title: string;
     text: string;
   };

--- a/twake/backend/node/src/services/channels/provider.ts
+++ b/twake/backend/node/src/services/channels/provider.ts
@@ -30,6 +30,7 @@ export type ChannelPrimaryKey = {
 export type ChannelActivityMessage = {
   date: number;
   sender: string;
+  sender_name: string;
   title: string;
   text: string;
 };

--- a/twake/backend/node/src/services/channels/services/channel/service.ts
+++ b/twake/backend/node/src/services/channels/services/channel/service.ts
@@ -332,6 +332,7 @@ export class Service implements ChannelService {
     entity.last_message = {
       date: channelActivityMessage.date,
       sender: channelActivityMessage.sender,
+      sender_name: channelActivityMessage.sender_name,
       title: channelActivityMessage.title,
       text: channelActivityMessage.text,
     };

--- a/twake/backend/node/src/services/channels/services/pubsub/new-channel-activity/index.ts
+++ b/twake/backend/node/src/services/channels/services/pubsub/new-channel-activity/index.ts
@@ -37,8 +37,9 @@ export class NewChannelActivityProcessor
           message: {
             date: message.date,
             sender: message.sender,
+            sender_name: message.sender_name,
             title: message.title,
-            text: message.text,
+            text: message.body,
           },
         },
         {

--- a/twake/backend/node/src/services/channels/types.ts
+++ b/twake/backend/node/src/services/channels/types.ts
@@ -50,4 +50,6 @@ export type ChannelActivityNotification = {
   sender: string;
   title: string;
   text: string;
+  sender_name: string;
+  body: string;
 };


### PR DESCRIPTION
New sub fields were added to last_message field of the channel entity

## Description
last_message field currently contains 4 fields: sender (user_id), date, title and text (username: message text). But currently in mobile application we need a little different data:
1. We need username separately (not as part of the text sub field)
2. Text sub field should contain only message itself without sender's name

In order to avoid breaking mobile notifications which is triggered by the same event as for updating last_message for the channel, I only appended the required fields to RabbitMQ data.

## Related Issue
https://github.com/linagora/Twake-Mobile/issues/433

## Motivation and Context
New mobile application design requires the above mentioned new fields

## How Has This Been Tested?
It wasn't tested

## Types of changes
Addition of the new fields to channel entity's last_message column, adjusted update logic 
