### PR TITLE
Set staticCSP to false in fastify-swagger options

### DIFF
--- a/twake/backend/node/src/core/platform/services/webserver/index.ts
+++ b/twake/backend/node/src/core/platform/services/webserver/index.ts
@@ -8,7 +8,7 @@ import WebServerAPI from "./provider";
 import jwtPlugin from "../auth/web/jwt";
 import swaggerPlugin from "fastify-swagger";
 import { SkipCLI } from "../../framework/decorators/skip";
-import { throws } from "assert";
+// import { throws } from "assert";
 export default class WebServerService extends TwakeService<WebServerAPI> implements WebServerAPI {
   name = "webserver";
   version = "1";
@@ -57,7 +57,7 @@ export default class WebServerService extends TwakeService<WebServerAPI> impleme
         docExpansion: "full",
         deepLinking: false,
       },
-      staticCSP: true,
+      staticCSP: false,
       transformStaticCSP: header => header,
       exposeRoute: true,
     });


### PR DESCRIPTION
## Description
If set to true, swagger doesn't work on installations which run on
insecure http connections

## Motivation and Context
staticSCP options if set to true, forces all the subsequent requests to swagger resources to be redirected to secure connection, which on local installation without SSL support won't work. Setting it to false doesn't affect security much, because it's just a public documentation.

## How Has This Been Tested?
Run it on local instance, nothing breaks.