### PR TITLE
🛠  Messages to node #1301 bux fixing

### DIFF
--- a/twake/backend/core/src/Twake/Discussion/Controller/Discussion.php
+++ b/twake/backend/core/src/Twake/Discussion/Controller/Discussion.php
@@ -78,6 +78,8 @@ class Discussion extends BaseController
             "channel_id" => $channel_id
         ]);
 
+        error_log("realtime: " . json_encode($array));
+
         if($removed){
 
             $event = Array(

--- a/twake/backend/core/src/Twake/Discussion/Controller/Discussion.php
+++ b/twake/backend/core/src/Twake/Discussion/Controller/Discussion.php
@@ -78,8 +78,6 @@ class Discussion extends BaseController
             "channel_id" => $channel_id
         ]);
 
-        error_log("realtime: " . json_encode($array));
-
         if($removed){
 
             $event = Array(

--- a/twake/backend/core/src/Twake/Discussion/Services/MessageSystem.php
+++ b/twake/backend/core/src/Twake/Discussion/Services/MessageSystem.php
@@ -147,11 +147,17 @@ class MessageSystem
                 $message["id"] = $response["resource"]["id"];
             }
 
+            $options = [];
+            if(isset($object["_once_replace_message_parent_message"])){
+                $options["previous_thread"] = $object["_once_replace_message_parent_message"] ?: $object["_once_replace_message"] ?: $object["id"];
+            }
+
             //New message in thread (also called for new threads because we set the parent_message_id automatically)
             if($object["parent_message_id"] && $newMessage){
 
                 $data = [
-                    "resource" => $message
+                    "resource" => $message,
+                    "options" => $options
                 ];
 
                 $response = $this->forwardToNode("POST", "/companies/".$channel["company_id"]."/threads/".($object["parent_message_id"] ?: $object["id"])."/messages", $data, $current_user, $application ? $application->getId() : null);
@@ -162,7 +168,8 @@ class MessageSystem
             if(!$newMessage){
 
                 $data = [
-                    "resource" => $message
+                    "resource" => $message,
+                    "options" => $options
                 ];
 
                 $response = $this->forwardToNode("POST", "/companies/".$channel["company_id"]."/threads/".($object["parent_message_id"] ?: $object["id"])."/messages/".$object["id"], $data, $current_user, $application ? $application->getId() : null);

--- a/twake/backend/core/src/Twake/Discussion/Services/MessageSystem.php
+++ b/twake/backend/core/src/Twake/Discussion/Services/MessageSystem.php
@@ -93,12 +93,17 @@ class MessageSystem
 
         if($object["id"]){
             //Manage message pin
-            $response = $this->forwardToNode("POST", "/companies/".$channel["company_id"]."/threads/".($object["parent_message_id"] ?: $object["id"])."/messages/".$object["id"]."/pin", ["pin" => [$object["pinned"]]], $current_user, $application ? $application->getId() : null);
+            $response = $this->forwardToNode("POST", "/companies/".$channel["company_id"]."/threads/".($object["parent_message_id"] ?: $object["id"])."/messages/".$object["id"]."/pin", ["pin" => $object["pinned"]], $current_user, $application ? $application->getId() : null);
+            error_log("pin result: ".json_encode($response["pinned_info"]));
         }
 
-        if($object["_user_reaction"]){
+        if(isset($object["_user_reaction"])){
             //Manage user reaction
-            $response = $this->forwardToNode("POST", "/companies/".$channel["company_id"]."/threads/".($object["parent_message_id"] ?: $object["id"])."/messages/".$object["id"]."/reaction", ["reactions" => [$object["_user_reaction"]]], $current_user, $application ? $application->getId() : null);
+            if($object["_user_reaction"]){
+                $list = [$object["_user_reaction"]];
+            }
+            $response = $this->forwardToNode("POST", "/companies/".$channel["company_id"]."/threads/".($object["parent_message_id"] ?: $object["id"])."/messages/".$object["id"]."/reaction", ["reactions" => $list], $current_user, $application ? $application->getId() : null);
+
         }else{
             //Manage message edition
 
@@ -203,8 +208,6 @@ class MessageSystem
             ];
         }
 
-        error_log(json_encode($object));
-
         return [
             "text" => $object["content"]["original_str"] ?: $object["content"]["fallback_string"],
             "blocks" => $blocks,
@@ -271,8 +274,6 @@ class MessageSystem
         $uri = str_replace("/private", "/internal/services/messages/v1", $this->app->getContainer()->getParameter("node.api")) . 
             ltrim($route, "/");
        
-        error_log($user);
-
         $key = $this->app->getContainer()->getParameter("jwt.secret");
         $payload = [
             "exp" => date("U") + 60,

--- a/twake/backend/core/src/Twake/Discussion/Services/MessageSystem.php
+++ b/twake/backend/core/src/Twake/Discussion/Services/MessageSystem.php
@@ -48,26 +48,40 @@ class MessageSystem
 
         $messages = [];
         foreach($response["resources"] as $message){
-            $messages[] = $this->convertFromNode($message, $channel);
-            if($message["last_replies"]){
-                foreach($message["last_replies"] as $reply){
-                    if($reply["id"] !== $message["id"])
-                        $messages[] = $this->convertFromNode($reply, $channel);
+            if($message["subtype"] != "deleted"){
+                $messages[] = $this->convertFromNode($message, $channel);
+                if($message["last_replies"]){
+                    foreach($message["last_replies"] as $reply){
+                        if($reply["id"] !== $message["id"] && $reply["subtype"] != "deleted")
+                            $messages[] = $this->convertFromNode($reply, $channel);
+                    }
                 }
             }
         }
 
-        if(count($messages) === 0
+        if(count($messages) < abs($limit)
             && !$options["id"]
             && !$options["id"]
             && !$offset
             && $limit > 0
             && !$parent_message_id ){
-            $init_message = Array(
-                "channel_id" => $options["channel_id"],
-                "hidden_data" => Array("type" => "init_channel")
-            );
-            return [$this->save($init_message, Array())];
+
+            $found = false;
+            foreach($messages as $message){
+                if($message["hidden_data"]["type"] === "init_channel"){
+                    $found = true;
+                }
+            }
+
+            if(!$found){
+                $init_message = Array(
+                    "channel_id" => $options["channel_id"],
+                    "hidden_data" => Array("type" => "init_channel"),
+                    "created_at" => 0
+                );
+                $init_message = $this->save($init_message, Array());
+                array_merge([$init_message], $messages);
+            }
         }
 
         return $messages;
@@ -90,12 +104,12 @@ class MessageSystem
 
         if($object["id"]){
             //Manage message pin
-            $response = $this->forwardToNode("POST", "/companies/".$channel["company_id"]."/threads/".($object["parent_message_id"] ?: $object["id"])."/messages/".$object["id"]."/pin", ["pin" => [$object["pinned"]]], $current_user, $application ? $application->getId() : null);
+            $response = $this->forwardToNode("POST", "/companies/".$channel["company_id"]."/threads/".($object["parent_message_id"] ?: $object["id"])."/messages/".$object["id"]."/pin", ["pin" => $object["pinned"]], $current_user, $application ? $application->getId() : null);
         }
 
-        if($object["_user_reaction"]){
+        if(isset($object["_user_reaction"])){
             //Manage user reaction
-            $response = $this->forwardToNode("POST", "/companies/".$channel["company_id"]."/threads/".($object["parent_message_id"] ?: $object["id"])."/messages/".$object["id"]."/reaction", ["reactions" => [$object["_user_reaction"]]], $current_user, $application ? $application->getId() : null);
+            $response = $this->forwardToNode("POST", "/companies/".$channel["company_id"]."/threads/".($object["parent_message_id"] ?: $object["id"])."/messages/".$object["id"]."/reaction", ["reactions" => $object["_user_reaction"] ? [$object["_user_reaction"]] : []], $current_user, $application ? $application->getId() : null);
         }else{
             //Manage message edition
 
@@ -222,14 +236,17 @@ class MessageSystem
 
         // Find the twacode block if exists or get the fallback string
         $prepared = [];
-        foreach( $message["blocks"] as $block ){
-            if($block["type"] === "twacode"){
-                $prepared = $block["elements"];
+        if($message["blocks"])
+            foreach( $message["blocks"] as $block ){
+                if($block["type"] === "twacode"){
+                    $prepared = $block["elements"];
+                }
+                if($block["type"] === "section" && count($prepared) === 0){
+                    $prepared = [["type" => "twacode", "content" => $block["text"]["mrkdwn"]["text"] ?: $block["text"]["plain_text"]["text"] ?: ""]];
+                }
             }
-            if($block["type"] === "section"){
-                $prepared = [["type" => "twacode", "content" => $block["text"]["mrkdwn"]["text"] ?: $block["text"]["plain_text"]["text"] ?: ""]];
-            }
-        }
+
+        error_log(json_encode($prepared));
 
         $phpMessage->setContent([
             "fallback_string" => $message["text"],

--- a/twake/backend/node/src/core/platform/services/database/services/orm/connectors/cassandra/typeTransforms.ts
+++ b/twake/backend/node/src/core/platform/services/database/services/orm/connectors/cassandra/typeTransforms.ts
@@ -102,7 +102,7 @@ export const transformValueFromDbString = (
     try {
       decryptedValue = decrypt(v, options.secret).data;
     } catch (err) {
-      logger.debug({ err }, `Can not decrypt data %o of type ${type}`, v);
+      logger.debug(`Can not decrypt data (${err.message}) %o of type ${type}`, v);
 
       decryptedValue = v;
     }

--- a/twake/backend/node/src/core/platform/services/database/services/orm/manager.ts
+++ b/twake/backend/node/src/core/platform/services/database/services/orm/manager.ts
@@ -47,6 +47,14 @@ export default class EntityManager<EntityType extends Record<string, any>> {
       }
     });
 
+    //Apply the onUpsert
+    for (const column in columnsDefinition) {
+      const definition = columnsDefinition[column];
+      if (definition.options.onUpsert) {
+        entity[definition.nodename] = definition.options.onUpsert(entity[definition.nodename]);
+      }
+    }
+
     this.toPersist = this.toPersist.filter(e => e !== entity);
     this.toPersist.push(_.cloneDeep(entity));
 

--- a/twake/backend/node/src/core/platform/services/database/services/orm/types.ts
+++ b/twake/backend/node/src/core/platform/services/database/services/orm/types.ts
@@ -1,13 +1,5 @@
 import { Column } from "./decorators";
 
-export class UpdatableEntity {
-  @Column("updated_at", "number", { onUpsert: _ => new Date().getTime() })
-  updated_at: number;
-
-  @Column("created_at", "number", { onUpsert: d => d || new Date().getTime() })
-  created_at: number;
-}
-
 export type EntityDefinition = {
   name: string;
   type: string;

--- a/twake/backend/node/src/core/platform/services/database/services/orm/types.ts
+++ b/twake/backend/node/src/core/platform/services/database/services/orm/types.ts
@@ -1,3 +1,13 @@
+import { Column } from "./decorators";
+
+export class UpdatableEntity {
+  @Column("updated_at", "number", { onUpsert: _ => new Date().getTime() })
+  updated_at: number;
+
+  @Column("created_at", "number", { onUpsert: d => d || new Date().getTime() })
+  created_at: number;
+}
+
 export type EntityDefinition = {
   name: string;
   type: string;
@@ -21,6 +31,7 @@ export type ColumnDefinition = {
 export type ColumnOptions = {
   order?: "ASC" | "DESC";
   generator?: ColumnType;
+  onUpsert?: (value: any) => any;
 };
 
 export type ColumnType =

--- a/twake/backend/node/src/services/channels/entities/channel-member.ts
+++ b/twake/backend/node/src/services/channels/entities/channel-member.ts
@@ -1,5 +1,6 @@
 import { Type } from "class-transformer";
 import { merge } from "lodash";
+import { UpdatableEntity } from "../../../core/platform/services/database/services/orm/types";
 import { Entity, Column } from "../../../core/platform/services/database/services/orm/decorators";
 import { ChannelMemberNotificationLevel, ChannelMemberType } from "../types";
 
@@ -11,7 +12,7 @@ import { ChannelMemberNotificationLevel, ChannelMemberType } from "../types";
   primaryKey: [["company_id", "workspace_id"], "user_id", "channel_id"],
   type: "user_channels",
 })
-export class ChannelMember {
+export class ChannelMember extends UpdatableEntity {
   /**
    * Primary key
    */

--- a/twake/backend/node/src/services/channels/entities/channel-member.ts
+++ b/twake/backend/node/src/services/channels/entities/channel-member.ts
@@ -1,6 +1,5 @@
 import { Type } from "class-transformer";
 import { merge } from "lodash";
-import { UpdatableEntity } from "../../../core/platform/services/database/services/orm/types";
 import { Entity, Column } from "../../../core/platform/services/database/services/orm/decorators";
 import { ChannelMemberNotificationLevel, ChannelMemberType } from "../types";
 
@@ -12,7 +11,7 @@ import { ChannelMemberNotificationLevel, ChannelMemberType } from "../types";
   primaryKey: [["company_id", "workspace_id"], "user_id", "channel_id"],
   type: "user_channels",
 })
-export class ChannelMember extends UpdatableEntity {
+export class ChannelMember {
   /**
    * Primary key
    */
@@ -82,6 +81,12 @@ export class ChannelMember extends UpdatableEntity {
   @Type(() => String)
   @Column("id", "string")
   id: string;
+
+  @Column("updated_at", "number", { onUpsert: _ => new Date().getTime() })
+  updated_at: number;
+
+  @Column("created_at", "number", { onUpsert: d => d || new Date().getTime() })
+  created_at: number;
 }
 
 export type ChannelMemberPrimaryKey = Pick<

--- a/twake/backend/node/src/services/channels/entities/channel.ts
+++ b/twake/backend/node/src/services/channels/entities/channel.ts
@@ -1,5 +1,4 @@
 import { Type } from "class-transformer";
-import { UpdatableEntity } from "../../../core/platform/services/database/services/orm/types";
 import { Entity, Column } from "../../../core/platform/services/database/services/orm/decorators";
 import { ChannelVisibility, ChannelType } from "../types";
 import { ChannelMember } from "./channel-member";
@@ -8,7 +7,7 @@ import { ChannelMember } from "./channel-member";
   primaryKey: [["company_id", "workspace_id"], "id"],
   type: "channels",
 })
-export class Channel extends UpdatableEntity {
+export class Channel {
   // uuid-v4
   @Type(() => String)
   @Column("company_id", "uuid", { generator: "uuid" })
@@ -56,6 +55,12 @@ export class Channel extends UpdatableEntity {
 
   @Column("connectors", "encoded_json")
   connectors: string[] = []; //list of app-ids
+
+  @Column("updated_at", "number", { onUpsert: _ => new Date().getTime() })
+  updated_at: number;
+
+  @Column("created_at", "number", { onUpsert: d => d || new Date().getTime() })
+  created_at: number;
 
   static isPrivateChannel(channel: Channel): boolean {
     return channel.visibility === ChannelVisibility.PRIVATE;

--- a/twake/backend/node/src/services/channels/entities/channel.ts
+++ b/twake/backend/node/src/services/channels/entities/channel.ts
@@ -1,4 +1,5 @@
 import { Type } from "class-transformer";
+import { UpdatableEntity } from "../../../core/platform/services/database/services/orm/types";
 import { Entity, Column } from "../../../core/platform/services/database/services/orm/decorators";
 import { ChannelVisibility, ChannelType } from "../types";
 import { ChannelMember } from "./channel-member";
@@ -7,7 +8,7 @@ import { ChannelMember } from "./channel-member";
   primaryKey: [["company_id", "workspace_id"], "id"],
   type: "channels",
 })
-export class Channel {
+export class Channel extends UpdatableEntity {
   // uuid-v4
   @Type(() => String)
   @Column("company_id", "uuid", { generator: "uuid" })

--- a/twake/backend/node/src/services/channels/entities/tab.ts
+++ b/twake/backend/node/src/services/channels/entities/tab.ts
@@ -1,4 +1,5 @@
 import { Type } from "class-transformer";
+import { UpdatableEntity } from "../../../core/platform/services/database/services/orm/types";
 import { Entity, Column } from "../../../core/platform/services/database/services/orm/decorators";
 import { ChannelType } from "../types";
 
@@ -6,7 +7,7 @@ import { ChannelType } from "../types";
   primaryKey: [["company_id", "workspace_id"], "channel_id", "id"],
   type: "channel_tabs",
 })
-export class ChannelTab {
+export class ChannelTab extends UpdatableEntity {
   // uuid-v4
   @Type(() => String)
   @Column("company_id", "string", { generator: "uuid" })

--- a/twake/backend/node/src/services/channels/entities/tab.ts
+++ b/twake/backend/node/src/services/channels/entities/tab.ts
@@ -1,5 +1,4 @@
 import { Type } from "class-transformer";
-import { UpdatableEntity } from "../../../core/platform/services/database/services/orm/types";
 import { Entity, Column } from "../../../core/platform/services/database/services/orm/decorators";
 import { ChannelType } from "../types";
 
@@ -7,7 +6,7 @@ import { ChannelType } from "../types";
   primaryKey: [["company_id", "workspace_id"], "channel_id", "id"],
   type: "channel_tabs",
 })
-export class ChannelTab extends UpdatableEntity {
+export class ChannelTab {
   // uuid-v4
   @Type(() => String)
   @Column("company_id", "string", { generator: "uuid" })
@@ -42,6 +41,12 @@ export class ChannelTab extends UpdatableEntity {
 
   @Column("col_order", "encoded_string")
   order: string;
+
+  @Column("updated_at", "number", { onUpsert: _ => new Date().getTime() })
+  updated_at: number;
+
+  @Column("created_at", "number", { onUpsert: d => d || new Date().getTime() })
+  created_at: number;
 }
 
 export type ChannelTabPrimaryKey = Pick<

--- a/twake/backend/node/src/services/files/entities/file.ts
+++ b/twake/backend/node/src/services/files/entities/file.ts
@@ -1,11 +1,12 @@
 import { Type } from "class-transformer";
+import { UpdatableEntity } from "../../../core/platform/services/database/services/orm/types";
 import { Entity, Column } from "../../../core/platform/services/database/services/orm/decorators";
 
 @Entity("files", {
   primaryKey: [["company_id"], "id"],
   type: "files",
 })
-export class File {
+export class File extends UpdatableEntity {
   @Type(() => String)
   @Column("company_id", "uuid")
   company_id: string;

--- a/twake/backend/node/src/services/files/entities/file.ts
+++ b/twake/backend/node/src/services/files/entities/file.ts
@@ -1,12 +1,11 @@
 import { Type } from "class-transformer";
-import { UpdatableEntity } from "../../../core/platform/services/database/services/orm/types";
 import { Entity, Column } from "../../../core/platform/services/database/services/orm/decorators";
 
 @Entity("files", {
   primaryKey: [["company_id"], "id"],
   type: "files",
 })
-export class File extends UpdatableEntity {
+export class File {
   @Type(() => String)
   @Column("company_id", "uuid")
   company_id: string;
@@ -24,6 +23,12 @@ export class File extends UpdatableEntity {
 
   @Column("encryption_key", "encoded_string")
   encryption_key: string;
+
+  @Column("updated_at", "number", { onUpsert: _ => new Date().getTime() })
+  updated_at: number;
+
+  @Column("created_at", "number", { onUpsert: d => d || new Date().getTime() })
+  created_at: number;
 
   @Column("metadata", "encoded_json")
   metadata: null | {

--- a/twake/backend/node/src/services/messages/api.ts
+++ b/twake/backend/node/src/services/messages/api.ts
@@ -81,6 +81,12 @@ export interface MessageThreadMessagesServiceAPI
   ): Promise<SaveResult<Message>>;
 
   getThread(thread: Thread, options: MessagesGetThreadOptions): Promise<MessageWithReplies>;
+
+  move(
+    item: Pick<Message, "id">,
+    options: { previous_thread: string },
+    context: ThreadExecutionContext,
+  ): Promise<void>;
 }
 
 export interface MessageViewsServiceAPI extends TwakeServiceProvider, Initializable {

--- a/twake/backend/node/src/services/messages/api.ts
+++ b/twake/backend/node/src/services/messages/api.ts
@@ -18,6 +18,7 @@ import {
   MessageViewListOptions,
   ThreadExecutionContext,
   MessageWithReplies,
+  MessagesGetThreadOptions,
 } from "./types";
 import { ParticipantObject, Thread, ThreadPrimaryKey } from "./entities/threads";
 import { Message, MessagePrimaryKey } from "./entities/messages";
@@ -78,6 +79,8 @@ export interface MessageThreadMessagesServiceAPI
     options: {},
     context: ThreadExecutionContext,
   ): Promise<SaveResult<Message>>;
+
+  getThread(thread: Thread, options: MessagesGetThreadOptions): Promise<MessageWithReplies>;
 }
 
 export interface MessageViewsServiceAPI extends TwakeServiceProvider, Initializable {

--- a/twake/backend/node/src/services/messages/entities/messages.ts
+++ b/twake/backend/node/src/services/messages/entities/messages.ts
@@ -1,5 +1,6 @@
 import { Type } from "class-transformer";
 import { merge } from "lodash";
+import { UpdatableEntity } from "../../../core/platform/services/database/services/orm/types";
 import { Column, Entity } from "../../../core/platform/services/database/services/orm/decorators";
 import { Block } from "../blocks-types";
 
@@ -21,7 +22,7 @@ export const TYPE = "messages";
     },
   },
 })
-export class Message {
+export class Message extends UpdatableEntity {
   @Type(() => String)
   @Column("thread_id", "timeuuid")
   thread_id: string;

--- a/twake/backend/node/src/services/messages/entities/messages.ts
+++ b/twake/backend/node/src/services/messages/entities/messages.ts
@@ -1,6 +1,5 @@
 import { Type } from "class-transformer";
 import { merge } from "lodash";
-import { UpdatableEntity } from "../../../core/platform/services/database/services/orm/types";
 import { Column, Entity } from "../../../core/platform/services/database/services/orm/decorators";
 import { Block } from "../blocks-types";
 
@@ -22,7 +21,7 @@ export const TYPE = "messages";
     },
   },
 })
-export class Message extends UpdatableEntity {
+export class Message {
   @Type(() => String)
   @Column("thread_id", "timeuuid")
   thread_id: string;
@@ -50,6 +49,9 @@ export class Message extends UpdatableEntity {
   @Type(() => Number)
   @Column("created_at", "number")
   created_at: number;
+
+  @Column("updated_at", "number", { onUpsert: _ => new Date().getTime() })
+  updated_at: number;
 
   @Type(() => String)
   @Column("user_id", "uuid")

--- a/twake/backend/node/src/services/messages/entities/threads.ts
+++ b/twake/backend/node/src/services/messages/entities/threads.ts
@@ -1,6 +1,5 @@
 import { Type } from "class-transformer";
 import { merge } from "lodash";
-import { UpdatableEntity } from "../../../core/platform/services/database/services/orm/types";
 import { Column, Entity } from "../../../core/platform/services/database/services/orm/decorators";
 
 export const TYPE = "threads";
@@ -8,7 +7,7 @@ export const TYPE = "threads";
   primaryKey: [["id"]],
   type: TYPE,
 })
-export class Thread extends UpdatableEntity {
+export class Thread {
   @Type(() => String)
   @Column("id", "timeuuid")
   id: string;
@@ -20,6 +19,9 @@ export class Thread extends UpdatableEntity {
   @Type(() => Number)
   @Column("created_at", "number")
   created_at: number;
+
+  @Column("updated_at", "number", { onUpsert: _ => new Date().getTime() })
+  updated_at: number;
 
   @Type(() => Number)
   @Column("last_activity", "number")

--- a/twake/backend/node/src/services/messages/entities/threads.ts
+++ b/twake/backend/node/src/services/messages/entities/threads.ts
@@ -1,5 +1,6 @@
 import { Type } from "class-transformer";
 import { merge } from "lodash";
+import { UpdatableEntity } from "../../../core/platform/services/database/services/orm/types";
 import { Column, Entity } from "../../../core/platform/services/database/services/orm/decorators";
 
 export const TYPE = "threads";
@@ -7,7 +8,7 @@ export const TYPE = "threads";
   primaryKey: [["id"]],
   type: TYPE,
 })
-export class Thread {
+export class Thread extends UpdatableEntity {
   @Type(() => String)
   @Column("id", "timeuuid")
   id: string;

--- a/twake/backend/node/src/services/messages/services/engine/index.ts
+++ b/twake/backend/node/src/services/messages/services/engine/index.ts
@@ -1,5 +1,5 @@
 import { localEventBus } from "../../../../core/platform/framework/pubsub";
-import { Initializable } from "../../../../core/platform/framework";
+import { Initializable, logger } from "../../../../core/platform/framework";
 import { MessageServiceAPI } from "../../api";
 import { MessageLocalEvent } from "../../types";
 import { ChannelViewProcessor } from "./processors/channel-view";
@@ -62,6 +62,7 @@ export class MessagesEngine implements Initializable {
       const thread = await this.threadRepository.findOne({
         id: e.resource.thread_id,
       });
+
       this.channelViewProcessor.process(thread, e);
       this.channelMarkedViewProcessor.process(thread, e);
       this.userInboxViewProcessor.process(thread, e);

--- a/twake/backend/node/src/services/messages/services/engine/processors/message-to-notifications/index.ts
+++ b/twake/backend/node/src/services/messages/services/engine/processors/message-to-notifications/index.ts
@@ -25,6 +25,12 @@ export class MessageToNotificationsProcessor {
 
   async process(thread: Thread, message: MessageLocalEvent): Promise<void> {
     logger.debug(`${this.name} - Share message with notification microservice`);
+
+    if (message.resource.ephemeral) {
+      logger.debug(`${this.name} - Cancel because message is ephemeral`);
+      return;
+    }
+
     try {
       const messageResource = message.resource;
 

--- a/twake/backend/node/src/services/messages/services/messages/operations.ts
+++ b/twake/backend/node/src/services/messages/services/messages/operations.ts
@@ -1,0 +1,137 @@
+import { SaveResult, OperationType } from "../../../../core/platform/framework/api/crud-service";
+import { logger, TwakeContext } from "../../../../core/platform/framework";
+import { Message } from "../../entities/messages";
+import {
+  BookmarkOperation,
+  PinOperation,
+  ReactionOperation,
+  ThreadExecutionContext,
+} from "../../types";
+import _ from "lodash";
+import { updateMessageReactions } from "./utils";
+import { DatabaseServiceAPI } from "../../../../core/platform/services/database/api";
+import { MessageServiceAPI } from "../../api";
+import Repository from "../../../../core/platform/services/database/services/orm/repository/repository";
+import { ThreadMessagesService } from "./service";
+
+export class ThreadMessagesOperationsService {
+  constructor(
+    private database: DatabaseServiceAPI,
+    private service: MessageServiceAPI,
+    private threadMessagesService: ThreadMessagesService,
+  ) {}
+  repository: Repository<Message>;
+
+  async init(context: TwakeContext): Promise<this> {
+    this.repository = await this.database.getRepository<Message>("messages", Message);
+    return this;
+  }
+
+  async pin(
+    operation: PinOperation,
+    options: {},
+    context: ThreadExecutionContext,
+  ): Promise<SaveResult<Message>> {
+    if (!context?.user?.server_request && !this.service.threads.checkAccessToThread(context)) {
+      logger.error(`Unable to write in thread ${context.thread.id}`);
+      throw Error("Can't edit this message.");
+    }
+
+    const message = await this.repository.findOne({
+      thread_id: context.thread.id,
+      id: operation.id,
+    });
+
+    if (!message) {
+      logger.error(`This message doesn't exists`);
+      throw Error("Can't edit this message.");
+    }
+
+    message.pinned_info = operation.pin
+      ? {
+          pinned_by: context.user.id,
+          pinned_at: new Date().getTime(),
+        }
+      : null;
+
+    logger.info(
+      `Updated message ${operation.id} pin to ${JSON.stringify(message.pinned_info)} thread ${
+        message.thread_id
+      }`,
+    );
+    await this.repository.save(message);
+    this.threadMessagesService.onSaved(message, { created: false }, context);
+    return new SaveResult<Message>("message", message, OperationType.UPDATE);
+  }
+
+  async reaction(
+    operation: ReactionOperation,
+    options: {},
+    context: ThreadExecutionContext,
+  ): Promise<SaveResult<Message>> {
+    if (!context?.user?.server_request && !this.service.threads.checkAccessToThread(context)) {
+      logger.error(`Unable to write in thread ${context.thread.id}`);
+      throw Error("Can't edit this message.");
+    }
+
+    const message = await this.repository.findOne({
+      thread_id: context.thread.id,
+      id: operation.id,
+    });
+
+    if (!message) {
+      logger.error(`This message doesn't exists`);
+      throw Error("Can't edit this message.");
+    }
+
+    //Update message reactions
+    updateMessageReactions(message, operation.reactions || [], context.user.id);
+
+    logger.info(
+      `Updated message ${operation.id} reactions to ${JSON.stringify(message.reactions)} thread ${
+        message.thread_id
+      }`,
+    );
+    await this.repository.save(message);
+    this.threadMessagesService.onSaved(message, { created: false }, context);
+    return new SaveResult<Message>("message", message, OperationType.UPDATE);
+  }
+
+  async bookmark(
+    operation: BookmarkOperation,
+    options: {},
+    context: ThreadExecutionContext,
+  ): Promise<SaveResult<Message>> {
+    const message = await this.repository.findOne({
+      thread_id: context.thread.id,
+      id: operation.id,
+    });
+
+    if (!message) {
+      logger.error(`This message doesn't exists`);
+      throw Error("Can't edit this message.");
+    }
+
+    //TODO add message to user bookmarks
+    message.bookmarks = message.bookmarks.filter(
+      b => !(b.user_id === context.user.id && b.bookmark_id === operation.bookmark_id),
+    );
+    if (operation.active) {
+      message.bookmarks.push({
+        user_id: context.user.id,
+        bookmark_id: operation.bookmark_id,
+        created_at: new Date().getTime(),
+      });
+    }
+
+    logger.info(
+      `Added bookmark to message ${operation.id} => ${JSON.stringify(
+        message.bookmarks,
+      )} to thread ${message.thread_id}`,
+    );
+    await this.repository.save(message);
+    this.threadMessagesService.onSaved(message, { created: false }, context);
+
+    return new SaveResult<Message>("message", message, OperationType.UPDATE);
+  }
+}

--- a/twake/backend/node/src/services/messages/services/messages/operations.ts
+++ b/twake/backend/node/src/services/messages/services/messages/operations.ts
@@ -69,6 +69,8 @@ export class ThreadMessagesOperationsService {
     options: {},
     context: ThreadExecutionContext,
   ): Promise<SaveResult<Message>> {
+    console.log("here (for reaction)", operation);
+
     if (!context?.user?.server_request && !this.service.threads.checkAccessToThread(context)) {
       logger.error(`Unable to write in thread ${context.thread.id}`);
       throw Error("Can't edit this message.");
@@ -83,6 +85,8 @@ export class ThreadMessagesOperationsService {
       logger.error(`This message doesn't exists`);
       throw Error("Can't edit this message.");
     }
+
+    console.log("react with: ", operation);
 
     //Update message reactions
     updateMessageReactions(message, operation.reactions || [], context.user.id);

--- a/twake/backend/node/src/services/messages/services/messages/operations.ts
+++ b/twake/backend/node/src/services/messages/services/messages/operations.ts
@@ -1,6 +1,6 @@
 import { SaveResult, OperationType } from "../../../../core/platform/framework/api/crud-service";
 import { logger, TwakeContext } from "../../../../core/platform/framework";
-import { Message } from "../../entities/messages";
+import { Message, TYPE as MessageTableName } from "../../entities/messages";
 import {
   BookmarkOperation,
   PinOperation,
@@ -23,7 +23,7 @@ export class ThreadMessagesOperationsService {
   repository: Repository<Message>;
 
   async init(context: TwakeContext): Promise<this> {
-    this.repository = await this.database.getRepository<Message>("messages", Message);
+    this.repository = await this.database.getRepository<Message>(MessageTableName, Message);
     return this;
   }
 

--- a/twake/backend/node/src/services/messages/services/messages/operations.ts
+++ b/twake/backend/node/src/services/messages/services/messages/operations.ts
@@ -69,8 +69,6 @@ export class ThreadMessagesOperationsService {
     options: {},
     context: ThreadExecutionContext,
   ): Promise<SaveResult<Message>> {
-    console.log("here (for reaction)", operation);
-
     if (!context?.user?.server_request && !this.service.threads.checkAccessToThread(context)) {
       logger.error(`Unable to write in thread ${context.thread.id}`);
       throw Error("Can't edit this message.");
@@ -85,8 +83,6 @@ export class ThreadMessagesOperationsService {
       logger.error(`This message doesn't exists`);
       throw Error("Can't edit this message.");
     }
-
-    console.log("react with: ", operation);
 
     //Update message reactions
     updateMessageReactions(message, operation.reactions || [], context.user.id);

--- a/twake/backend/node/src/services/messages/services/messages/service.ts
+++ b/twake/backend/node/src/services/messages/services/messages/service.ts
@@ -312,7 +312,7 @@ export class ThreadMessagesService implements MessageThreadMessagesServiceAPI {
     },
   ])
   async onSaved(message: Message, options: { created: boolean }, context: ThreadExecutionContext) {
-    if (options.created) {
+    if (options.created && !message.ephemeral) {
       await this.service.threads.addReply(message.thread_id);
     }
 

--- a/twake/backend/node/src/services/messages/services/messages/service.ts
+++ b/twake/backend/node/src/services/messages/services/messages/service.ts
@@ -146,8 +146,6 @@ export class ThreadMessagesService implements MessageThreadMessagesServiceAPI {
       throw Error("Can't edit this message.");
     }
 
-    console.log("In 'pin' method");
-
     const message = await this.repository.findOne({
       thread_id: context.thread.id,
       id: operation.id,
@@ -185,8 +183,6 @@ export class ThreadMessagesService implements MessageThreadMessagesServiceAPI {
       throw Error("Can't edit this message.");
     }
 
-    console.log("In 'reaction' method");
-
     const message = await this.repository.findOne({
       thread_id: context.thread.id,
       id: operation.id,
@@ -198,7 +194,7 @@ export class ThreadMessagesService implements MessageThreadMessagesServiceAPI {
     }
 
     //Update message reactions
-    updateMessageReactions(message, operation.reactions, context.user.id);
+    updateMessageReactions(message, operation.reactions || [], context.user.id);
 
     logger.info(
       `Updated message ${operation.id} reactions to ${JSON.stringify(message.reactions)} thread ${
@@ -363,6 +359,9 @@ function updateMessageReactions(message: Message, selectedReactions: string[], u
     if (selectedReactions.includes(key)) {
       reactions[key].count++;
       reactions[key].users.push(userId);
+    }
+    if (reactions[key].count === 0) {
+      delete reactions[key];
     }
   }
   message.reactions = Object.values(reactions);

--- a/twake/backend/node/src/services/messages/services/messages/service.ts
+++ b/twake/backend/node/src/services/messages/services/messages/service.ts
@@ -165,7 +165,7 @@ export class ThreadMessagesService implements MessageThreadMessagesServiceAPI {
     this.onSaved(message, { created: false }, context);
 
     //Server and application can definively remove a message
-    if (context.user.server_request || context.user.application_id) {
+    if (context.user.server_request || context.user.application_id || message.application_id) {
       await this.repository.remove(message);
     }
 

--- a/twake/backend/node/src/services/messages/services/messages/utils.ts
+++ b/twake/backend/node/src/services/messages/services/messages/utils.ts
@@ -85,7 +85,10 @@ export function getDefaultMessageInstance(item: Partial<Message>, context: Threa
   });
 
   if (context.user.server_request) {
-    instance = _.assign(instance, item);
+    instance = _.assign(
+      instance,
+      _.pickBy(item, v => v !== undefined),
+    );
   }
 
   return instance;

--- a/twake/backend/node/src/services/messages/services/messages/utils.ts
+++ b/twake/backend/node/src/services/messages/services/messages/utils.ts
@@ -1,3 +1,4 @@
+import _ from "lodash";
 import { getInstance, Message, MessageReaction } from "../../entities/messages";
 import { ThreadExecutionContext } from "../../types";
 
@@ -49,7 +50,7 @@ export function updateMessageReactions(
 }
 
 export function getDefaultMessageInstance(item: Partial<Message>, context: ThreadExecutionContext) {
-  return getInstance({
+  let instance = getInstance({
     id: undefined,
     ephemeral:
       (context?.user?.application_id || context?.user?.server_request) && item.ephemeral
@@ -82,4 +83,10 @@ export function getDefaultMessageInstance(item: Partial<Message>, context: Threa
           }
         : null, // Only apps and server can set an override on a message
   });
+
+  if (context.user.server_request) {
+    instance = _.assign(instance, item);
+  }
+
+  return instance;
 }

--- a/twake/backend/node/src/services/messages/services/messages/utils.ts
+++ b/twake/backend/node/src/services/messages/services/messages/utils.ts
@@ -23,26 +23,28 @@ export function updateMessageReactions(
   selectedReactions: string[],
   userId: string,
 ) {
-  let reactions: { [key: string]: MessageReaction } = {};
-  for (const reaction of message.reactions || []) {
-    reactions[reaction.name] = reaction;
-  }
-  for (const reaction of selectedReactions) {
-    reactions[reaction] = reactions[reaction] || { name: reaction, count: 0, users: [] };
-  }
-  for (const key in reactions) {
-    if (reactions[key].users.includes(userId)) {
-      reactions[key].count--;
-      reactions[key].users = reactions[key].users.filter(u => u != userId);
+  let reactions: Map<string, MessageReaction> = new Map<string, MessageReaction>();
+  [...message.reactions].forEach(r => reactions.set(r.name, r));
+  [...selectedReactions].forEach(r =>
+    reactions.set(r, reactions.get(r) || { name: r, count: 0, users: [] }),
+  );
+
+  reactions.forEach((reaction, key) => {
+    if (reaction.users.includes(userId)) {
+      reaction.count--;
+      reaction.users = reaction.users.filter(u => u != userId);
     }
     if (selectedReactions.includes(key)) {
-      reactions[key].count++;
-      reactions[key].users.push(userId);
+      reaction.count++;
+      reaction.users.push(userId);
     }
-    if (reactions[key].count === 0) {
-      delete reactions[key];
+    if (reaction.count === 0) {
+      reactions.delete(key);
+    } else {
+      reactions.set(key, reaction);
     }
-  }
+  });
+
   message.reactions = Object.values(reactions);
 }
 

--- a/twake/backend/node/src/services/messages/services/messages/utils.ts
+++ b/twake/backend/node/src/services/messages/services/messages/utils.ts
@@ -1,0 +1,83 @@
+import { getInstance, Message, MessageReaction } from "../../entities/messages";
+import { ThreadExecutionContext } from "../../types";
+
+export function getSubtype(
+  item: Pick<Message, "subtype">,
+  context?: ThreadExecutionContext,
+): null | "application" | "deleted" | "system" {
+  //Application request
+  if (context?.user?.application_id) {
+    return item.subtype === "application" ? "application" : null;
+  }
+  //System request
+  else if (context?.user?.server_request) {
+    return item.subtype;
+  }
+
+  //User cannot set a subtype itself
+  return null;
+}
+
+export function updateMessageReactions(
+  message: Message,
+  selectedReactions: string[],
+  userId: string,
+) {
+  let reactions: { [key: string]: MessageReaction } = {};
+  for (const reaction of message.reactions || []) {
+    reactions[reaction.name] = reaction;
+  }
+  for (const reaction of selectedReactions) {
+    reactions[reaction] = reactions[reaction] || { name: reaction, count: 0, users: [] };
+  }
+  for (const key in reactions) {
+    if (reactions[key].users.includes(userId)) {
+      reactions[key].count--;
+      reactions[key].users = reactions[key].users.filter(u => u != userId);
+    }
+    if (selectedReactions.includes(key)) {
+      reactions[key].count++;
+      reactions[key].users.push(userId);
+    }
+    if (reactions[key].count === 0) {
+      delete reactions[key];
+    }
+  }
+  message.reactions = Object.values(reactions);
+}
+
+export function getDefaultMessageInstance(item: Partial<Message>, context: ThreadExecutionContext) {
+  return getInstance({
+    id: undefined,
+    ephemeral:
+      (context?.user?.application_id || context?.user?.server_request) && item.ephemeral
+        ? item.ephemeral
+        : null,
+    thread_id: context.thread.id,
+    type: context?.user?.server_request && item.type === "event" ? "event" : "message",
+    subtype: getSubtype({ subtype: item?.subtype || null }, context),
+    created_at: new Date().getTime(),
+    user_id: context.user.id,
+    application_id: context?.user?.application_id || null,
+    text: item.text || "",
+    blocks: item.blocks || [],
+    files: item.files || null,
+    context: item.context || null,
+    edited: null, //Message cannot be created with edition status
+    pinned_info: item.pinned_info
+      ? {
+          pinned_at: new Date().getTime(),
+          pinned_by: context.user.id,
+        }
+      : null,
+    reactions: null, // Reactions cannot be set on creation
+    bookmarks: null,
+    override:
+      (context?.user?.application_id || context?.user?.server_request) && item.override
+        ? {
+            title: item.override.title,
+            picture: item.override.picture,
+          }
+        : null, // Only apps and server can set an override on a message
+  });
+}

--- a/twake/backend/node/src/services/messages/services/threads/service.ts
+++ b/twake/backend/node/src/services/messages/services/threads/service.ts
@@ -132,9 +132,13 @@ export class ThreadsService
    */
   async addReply(threadId: string) {
     const thread = await this.repository.findOne({ id: threadId });
-    thread.answers++;
-    thread.last_activity = new Date().getTime();
-    await this.repository.save(thread);
+    if (thread) {
+      thread.answers++;
+      thread.last_activity = new Date().getTime();
+      await this.repository.save(thread);
+    } else {
+      throw new Error("Try to add reply count to inexistant thread");
+    }
   }
 
   /**

--- a/twake/backend/node/src/services/messages/services/threads/service.ts
+++ b/twake/backend/node/src/services/messages/services/threads/service.ts
@@ -180,8 +180,12 @@ export class ThreadsService
     throw new Error("CRUD method not used.");
   }
 
-  delete(pk: Pick<Thread, "id">, context?: ExecutionContext): Promise<DeleteResult<Thread>> {
-    throw new Error("CRUD method not used.");
+  async delete(pk: Pick<Thread, "id">, context?: ExecutionContext): Promise<DeleteResult<Thread>> {
+    const thread = await this.repository.findOne(pk);
+    if (context.user.server_request) {
+      await this.repository.remove(thread);
+    }
+    return new DeleteResult("thread", thread, context.user.server_request && !!thread);
   }
 
   list<ListOptions>(

--- a/twake/backend/node/src/services/messages/types.ts
+++ b/twake/backend/node/src/services/messages/types.ts
@@ -70,3 +70,9 @@ export interface MessageViewListOptions {
 }
 
 export interface MessageListQueryParameters extends PaginationQueryParameters {}
+
+export type PinOperation = { id: string; pin: boolean };
+
+export type ReactionOperation = { id: string; reactions: string[] };
+
+export type BookmarkOperation = { id: string; bookmark_id: string; active: boolean };

--- a/twake/backend/node/src/services/messages/types.ts
+++ b/twake/backend/node/src/services/messages/types.ts
@@ -90,3 +90,6 @@ export interface BookmarkOperation {
 export interface MessagesSaveOptions {
   previous_thread?: string; //If message was in a previous thread before (moved) then this indicate when is it from
 }
+export interface MessagesGetThreadOptions {
+  replies_per_thread?: number;
+}

--- a/twake/backend/node/src/services/messages/types.ts
+++ b/twake/backend/node/src/services/messages/types.ts
@@ -71,8 +71,22 @@ export interface MessageViewListOptions {
 
 export interface MessageListQueryParameters extends PaginationQueryParameters {}
 
-export type PinOperation = { id: string; pin: boolean };
+export interface PinOperation {
+  id: string;
+  pin: boolean;
+}
 
-export type ReactionOperation = { id: string; reactions: string[] };
+export interface ReactionOperation {
+  id: string;
+  reactions: string[];
+}
 
-export type BookmarkOperation = { id: string; bookmark_id: string; active: boolean };
+export interface BookmarkOperation {
+  id: string;
+  bookmark_id: string;
+  active: boolean;
+}
+
+export interface MessagesSaveOptions {
+  previous_thread?: string; //If message was in a previous thread before (moved) then this indicate when is it from
+}

--- a/twake/backend/node/src/services/messages/web/controllers/messages.ts
+++ b/twake/backend/node/src/services/messages/web/controllers/messages.ts
@@ -32,12 +32,26 @@ export class MessagesController
       };
       Body: {
         resource: Message;
+        options: {
+          previous_thread: string;
+        };
       };
     }>,
     reply: FastifyReply,
   ): Promise<ResourceUpdateResponse<Message>> {
     const context = getThreadExecutionContext(request);
     try {
+      if (request.body.options?.previous_thread) {
+        //First move the message to another thread, then edit it
+        await this.service.messages.move(
+          { id: request.params.message_id || undefined },
+          {
+            previous_thread: request.body.options?.previous_thread,
+          },
+          context,
+        );
+      }
+
       const result = await this.service.messages.save(
         {
           id: request.params.message_id || undefined,

--- a/twake/backend/node/test/e2e/messages/messages.user-bookmarks.realtime.spec.ts
+++ b/twake/backend/node/test/e2e/messages/messages.user-bookmarks.realtime.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, beforeEach, afterEach } from "@jest/globals";
 import io from "socket.io-client";
 import { TestPlatform, init } from "../setup";
 import { MessageServiceAPI } from "../../../src/services/messages/api";
+import { TwakePlatform } from "../../../src/core/platform/platform";
 
 describe("The Bookmarks Realtime feature", () => {
   const url = "/internal/services/messages/v1";
@@ -131,7 +132,7 @@ describe("The Bookmarks Realtime feature", () => {
   });
 });
 
-function getContext(platform) {
+function getContext(platform: TestPlatform) {
   return {
     company: { id: platform.workspace.company_id },
     user: { id: platform.currentUser.id },

--- a/twake/backend/node/test/e2e/messages/messages.user-bookmarks.spec.ts
+++ b/twake/backend/node/test/e2e/messages/messages.user-bookmarks.spec.ts
@@ -191,7 +191,7 @@ describe("The Messages User Bookmarks feature", () => {
   });
 });
 
-function getContext(platform) {
+function getContext(platform: TestPlatform) {
   return {
     company: { id: platform.workspace.company_id },
     user: { id: platform.currentUser.id },

--- a/twake/frontend/src/app/scenes/Apps/Messages/Message/Message.tsx
+++ b/twake/frontend/src/app/scenes/Apps/Messages/Message/Message.tsx
@@ -91,14 +91,21 @@ export default class MessageComponent extends Component<Props> {
     if (!this.message) {
       return [];
     }
-    return ((Collections.get('messages')
-      .findBy({
+    return (
+      (Collections.get('messages').findBy({
         channel_id: this.message.channel_id,
         parent_message_id: this.message.id,
         _user_ephemeral: undefined,
-      }) || []) as Message[])
+      }) || []) as Message[]
+    )
       .filter(i => !i._user_ephemeral)
-      .sort((a, b) => (a.creation_date || 0) - (b.creation_date || 0));
+      .sort((a, b) =>
+        a?.hidden_data?.type === 'init_channel'
+          ? -1
+          : b?.hidden_data?.type === 'init_channel'
+          ? 1
+          : (a.creation_date || 0) - (b.creation_date || 0),
+      );
   }
 
   render() {
@@ -140,11 +147,7 @@ export default class MessageComponent extends Component<Props> {
           message={message}
           className={canDropIn ? 'has-droppable ' : ''}
         >
-          <ThreadSection
-            small={linkToThread}
-            message={message}
-            head
-          >
+          <ThreadSection small={linkToThread} message={message} head>
             <MessageContent
               key={message?._last_modified || message?.front_id}
               threadHeader={this.props.threadHeader}
@@ -185,13 +188,7 @@ export default class MessageComponent extends Component<Props> {
                   previousMessageId={tmp_previous_message?.id || ''}
                   unreadAfter={this.props.unreadAfter || 0}
                 />,
-                <ThreadSection
-                  canDrag
-                  alinea
-                  message={message}
-                  small
-                  key={message.front_id}
-                >
+                <ThreadSection canDrag alinea message={message} small key={message.front_id}>
                   <MessageContent
                     message={message}
                     collectionKey={this.props.collectionKey}

--- a/twake/frontend/src/app/services/user/user.js
+++ b/twake/frontend/src/app/services/user/user.js
@@ -185,7 +185,7 @@ class User {
         Api.post('users/all/get', { id: ids }, res => {
           if (res.data) {
             res.data.forEach((user, index) => {
-              if (!user) {
+              if (!user || !user.id) {
                 this.stop_async_get[ids[index]] = true;
               } else {
                 callback && callback(user);

--- a/twake/frontend/yarn.lock
+++ b/twake/frontend/yarn.lock
@@ -6657,9 +6657,9 @@ dns-equal@^1.0.0:
   integrity sha1-s55/HabrCnW6nBcySzR1PEfgZU0=
 
 dns-packet@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/dns-packet/-/dns-packet-1.3.1.tgz#12aa426981075be500b910eedcd0b47dd7deda5a"
-  integrity sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/dns-packet/-/dns-packet-1.3.4.tgz#e3455065824a2507ba886c55a89963bb107dec6f"
+  integrity sha512-BQ6F4vycLXBvdrJZ6S3gZewt6rcrks9KBgM9vrhW+knGRqc8uEdT7fuCwloc7nny5xNoMJ17HGH0R/6fpo8ECA==
   dependencies:
     ip "^1.1.0"
     safe-buffer "^5.0.1"


### PR DESCRIPTION
- [x] Check applications still works with php api forwarded to node / ephemerals
- [x] Remove threads when empty
- [x] Remove message fix
- [x] Ephemerals: closable by all options fix
- [x] Thread update (number of answers etc) realtime update
- [x] Pin / reaction not working as expected bug
- [x] Convert maximum possible Twacode <-> Blocks
- [x] Init message order is wrong (appear after "you have been added to the channel") -> ~~must also be moved to node~~ it is depreciated and must be done by frontend from now on (so stored in frontend as a monkeyfix in the meanwhile)
- [x] Drag drop to other threads and out of thread too
