### PR TITLE
🛠 Ability to create global indexes

### DIFF
--- a/twake/backend/node/src/core/crypto/index.ts
+++ b/twake/backend/node/src/core/crypto/index.ts
@@ -1,5 +1,6 @@
 import legacy from "./legacy";
 import v1 from "./v1";
+import { createHash } from "crypto";
 
 export type CryptoResult = {
   /**
@@ -14,7 +15,7 @@ export type CryptoResult = {
    * Did we encrypted | decrypted the data? true if yes.
    */
   done?: boolean;
-}
+};
 
 export function decrypt(data: string, encryptionKey: string): CryptoResult {
   const result = legacy.decrypt(data, encryptionKey);
@@ -27,4 +28,8 @@ export function decrypt(data: string, encryptionKey: string): CryptoResult {
 
 export function encrypt(value: any, encryptionKey: any): CryptoResult {
   return v1.encrypt(value, encryptionKey);
+}
+
+export function md5(value: string): string {
+  return createHash("md5").update(value).digest("hex");
 }

--- a/twake/backend/node/src/core/platform/services/database/services/orm/connectors/cassandra/cassandra.ts
+++ b/twake/backend/node/src/core/platform/services/database/services/orm/connectors/cassandra/cassandra.ts
@@ -217,7 +217,7 @@ export class CassandraConnector extends AbstractConnector<
 
     if (primaryKey.length === 0) {
       logger.error(
-        "services.database.orm.cassandra - Primary key was not defined for table " + entity.name,
+        `services.database.orm.cassandra - Primary key was not defined for table ${entity.name}`,
       );
       return false;
     }
@@ -239,10 +239,10 @@ export class CassandraConnector extends AbstractConnector<
     });
     const clusteringOrderByString =
       clusteringOrderBy.length > 0
-        ? "WITH CLUSTERING ORDER BY (" + clusteringOrderBy.join(", ") + ")"
+        ? `WITH CLUSTERING ORDER BY (${clusteringOrderBy.join(", ")})`
         : "";
 
-    const allKeys = ["(" + partitionKey.join(", ") + ")", ...clusteringKeys];
+    const allKeys = [`(${partitionKey.join(", ")})`, ...clusteringKeys];
     const primaryKeyString = `(${allKeys.join(", ")})`;
 
     const columnsString = Object.keys(columns)
@@ -294,7 +294,7 @@ export class CassandraConnector extends AbstractConnector<
     if (entity.options.globalIndexes) {
       for (const globalIndex of entity.options.globalIndexes) {
         const indexName = globalIndex.join("_");
-        const indexDbName = "index_" + md5(indexName);
+        const indexDbName = `index_${md5(indexName)}`;
 
         let query = `CREATE INDEX ${this.options.keyspace}.${indexDbName} 
                       ON ${this.options.keyspace}.${entity.name} 
@@ -456,14 +456,10 @@ export class CassandraConnector extends AbstractConnector<
     if (Object.keys(filters).some(key => pk.indexOf(key) < 0)) {
       //Filter not in primary key
       throw new Error(
-        "All filter parameters must be defined in entity primary key, got: " +
-          JSON.stringify(Object.keys(filters)) +
-          " on table " +
-          entityDefinition.name +
-          " but pk is " +
-          JSON.stringify(pk) +
-          ", instance was " +
-          JSON.stringify(instance),
+        `All filter parameters must be defined in entity primary key,
+          got: ${JSON.stringify(Object.keys(filters))}
+          on table ${entityDefinition.name} but pk is ${JSON.stringify(pk)},
+          instance was ${JSON.stringify(instance)}`,
       );
     }
 

--- a/twake/backend/node/src/core/platform/services/database/services/orm/decorators/entity.ts
+++ b/twake/backend/node/src/core/platform/services/database/services/orm/decorators/entity.ts
@@ -4,6 +4,7 @@ type EntityOption = {
   type?: string;
   ttl?: number;
   primaryKey: (string | string[])[];
+  globalIndexes?: string[][];
   search?: {
     source: (entity: any) => any; //Should return an object that will be indexed
     index?: string; //Index name

--- a/twake/backend/node/src/core/platform/services/database/services/orm/types.ts
+++ b/twake/backend/node/src/core/platform/services/database/services/orm/types.ts
@@ -5,6 +5,7 @@ export type EntityDefinition = {
   type: string;
   options: {
     primaryKey: (string | string[])[];
+    globalIndexes?: string[][];
     ttl?: number;
     search?: {
       source: <Entity>(entity: Entity) => any; //Should return an object that will be indexed

--- a/twake/backend/node/src/services/user/entities/user.ts
+++ b/twake/backend/node/src/services/user/entities/user.ts
@@ -5,6 +5,7 @@ export const TYPE = "user";
 
 @Entity(TYPE, {
   primaryKey: [["id"]],
+  globalIndexes: [["email"]],
   type: TYPE,
 })
 export default class User {
@@ -26,7 +27,7 @@ export default class User {
   public get status_icon(): string {
     if (this._status_icon && this._status_icon.startsWith("[\\")) {
       try {
-        const parsed = JSON.parse(this._status_icon.replace(/\\"/g, "\"").replace(/\\\\/g, "\\"));
+        const parsed = JSON.parse(this._status_icon.replace(/\\"/g, '"').replace(/\\\\/g, "\\"));
         return `${parsed[0]} ${parsed[1]}`;
       } catch (e) {
         return "";


### PR DESCRIPTION
This is used for the user table as a temporary solution. Reminder: the goal is to not use any advanced indexes on Scylla or Cassandra because Cassandra marked them as experimental, then depreciated.