### PR TITLE
#1533 Allow to edit the channel description field when user leave it blank

### DIFF
--- a/twake/frontend/src/app/scenes/Client/ChannelsBar/Modals/ChannelTemplateEditor.tsx
+++ b/twake/frontend/src/app/scenes/Client/ChannelsBar/Modals/ChannelTemplateEditor.tsx
@@ -10,7 +10,7 @@ import AccessRightsService from 'app/services/AccessRightsService';
 
 type Props = {
   channel: ChannelType | undefined;
-  onChange: (channelEntries: any) => void;
+  onChange: (channelEntries: Partial<ChannelType>) => void;
   currentUserId?: string;
   defaultVisibility?: ChannelType['visibility'];
 };

--- a/twake/frontend/src/app/scenes/Client/ChannelsBar/Modals/ChannelWorkspaceEditor.tsx
+++ b/twake/frontend/src/app/scenes/Client/ChannelsBar/Modals/ChannelWorkspaceEditor.tsx
@@ -50,7 +50,7 @@ const ChannelWorkspaceEditor: FC<Props> = ({
       const insertedChannel = ChannelsCollections.findOne(channel.id, { withoutBackend: true });
       insertedChannel.data = _.assign(insertedChannel.data, {
         name: newChannel.name || channel.data.name,
-        description: newChannel.description || channel.data.description,
+        description: newChannel.description,
         icon: newChannel.icon || channel.data.icon,
         is_default: newChannel.is_default || false,
         visibility:

--- a/twake/frontend/src/app/scenes/Client/ChannelsBar/Modals/ChannelWorkspaceEditor.tsx
+++ b/twake/frontend/src/app/scenes/Client/ChannelsBar/Modals/ChannelWorkspaceEditor.tsx
@@ -5,7 +5,7 @@ import ModalManager from 'app/components/Modal/ModalManager';
 import ObjectModal from 'components/ObjectModal/ObjectModal';
 import Collections from 'app/services/CollectionsReact/Collections';
 import { ChannelType, ChannelResource } from 'app/models/Channel';
-import { Typography, Button } from 'antd';
+import { Button } from 'antd';
 import ChannelMembersList from './ChannelMembersList';
 import RouterServices from 'app/services/RouterService';
 import _ from 'lodash';
@@ -35,8 +35,29 @@ const ChannelWorkspaceEditor: FC<Props> = ({
     workspace_id: workspaceId,
   };
 
-  const onChange = (channelEntries: ChannelType): ChannelType => {
-    setDisabled((channelEntries.name || '').trim().length ? true : false);
+  const onChange = (channelEntries: Partial<ChannelType>): ChannelType => {
+    const shouldDisabled =
+      ((channelEntries.name || '').trim().length ? false : true) ||
+      _.isEqual(
+        {
+          channel_group: channelEntries.channel_group,
+          description: channelEntries.description,
+          icon: channelEntries.icon,
+          is_default: channelEntries.is_default,
+          name: channelEntries.name,
+          visibility: channelEntries.visibility,
+        },
+        {
+          channel_group: channel?.data.channel_group,
+          description: channel?.data.description,
+          icon: channel?.data.icon,
+          is_default: channel?.data.is_default,
+          name: channel?.data.name,
+          visibility: channel?.data.visibility,
+        },
+      );
+
+    setDisabled(shouldDisabled);
     return (newChannel = channelEntries);
   };
 
@@ -83,16 +104,14 @@ const ChannelWorkspaceEditor: FC<Props> = ({
       footer={
         <Button
           loading={loading}
+          onClick={upsertChannel}
           className="small"
           block={true}
           type="primary"
+          disabled={disabled}
           style={{
             width: 'auto',
             float: 'right',
-          }}
-          disabled={!disabled}
-          onClick={() => {
-            upsertChannel();
           }}
         >
           {Languages.t(channel?.id ? 'general.edit' : 'general.create')}


### PR DESCRIPTION
## Allow to edit the channel description field when user leave it blank
https://user-images.githubusercontent.com/36481167/128495157-d4140edc-0a5c-4736-816b-494670c6dbbf.mp4

## Fix disabled button during edition in ChannelWorkspaceEditor
https://user-images.githubusercontent.com/36481167/128510714-e52ccaf8-6e05-4b1a-913a-94a2654e8d13.mp4



