### PR TITLE
certbot-auto script is no more available

### DIFF
--- a/twake/docker/nginx-static-yarn/Dockerfile
+++ b/twake/docker/nginx-static-yarn/Dockerfile
@@ -15,8 +15,13 @@ RUN rm /etc/nginx/sites-enabled/default
 
 RUN usermod -u 1000 www-data
 
-RUN wget https://dl.eff.org/certbot-auto
-RUN chmod a+x certbot-auto
+RUN apt-get remove certbot
+RUN apt-get install -y python3 python3-venv libaugeas0
+RUN python3 -m venv /opt/certbot/
+RUN /opt/certbot/bin/pip install --upgrade pip
+RUN /opt/certbot/bin/pip install certbot
+RUN ln -s /opt/certbot/bin/certbot /usr/bin/certbot
+
 RUN apt-get update && apt-get install -y \
   augeas-lenses binutils cpp cpp-8 dh-python gcc gcc-8 libasan5 libatomic1 \
   libaugeas0 libc-dev-bin libc6-dev libcilkrts5 libexpat1-dev \


### PR DESCRIPTION
'build-nginx' Github Actions is failing.

The root cause comes from the change of Debian repositories (new stable version introduce August the 14th),
then the GPG keys had changed:
```
W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: https://dl.yarnpkg.com/debian stable InRelease: The following signatures were invalid: EXPKEYSIG 23E7166788B63E1E Yarn Packaging <yarn@dan.cx>
```

So we have to regenerate the root image used in the underlying Docker container.

The problem is that Certbot has changed and the initial script is no more available,
we should use pip to install it instead.