### PR TITLE
📈 Fix anonymousId in tracker

### DIFF
--- a/twake/backend/node/src/core/platform/services/tracker/index.ts
+++ b/twake/backend/node/src/core/platform/services/tracker/index.ts
@@ -108,7 +108,7 @@ export default class Tracker extends TwakeService<TrackerAPI> implements Tracker
     callback?: (err: Error) => void,
   ): Promise<void> {
     const analiticsIdentity = {
-      userId: identity.user?.allow_tracking ? identity.user.identity_provider_id : `anonymous-${md5(identity.user.identity_provider_id)}`,
+      userId: identity.user?.allow_tracking ? identity.user.identity_provider_id : `anonymous-${md5(identity.user.identity_provider_id || "")}`,
       ...identity, //Fixme: right now we use this to send onboarding emails so user is not completely anonymous yet
     };
 
@@ -146,8 +146,7 @@ export default class Tracker extends TwakeService<TrackerAPI> implements Tracker
       event.event = `twake:${event.event}`;
       analytics.track(
         {
-          userId: event.user?.allow_tracking ? event.user.identity_provider_id : undefined,
-          anonymousId: "anonymous",
+          userId: event.user?.allow_tracking ? event.user.identity_provider_id : `anonymous-${md5(event.user.identity_provider_id || "")}`,
           ...event,
         },
         callback,

--- a/twake/backend/node/src/core/platform/services/tracker/index.ts
+++ b/twake/backend/node/src/core/platform/services/tracker/index.ts
@@ -5,7 +5,7 @@ import TrackerAPI from "./provider";
 import { localEventBus } from "../../framework/pubsub";
 import { IdentifyObjectType, TrackedEventType, TrackerConfiguration } from "./types";
 import { ResourceEventsPayload } from "../../../../utils/types";
-import { md5 } from "src/core/crypto";
+import { md5 } from "../../../../core/crypto";
 
 @Consumes([])
 export default class Tracker extends TwakeService<TrackerAPI> implements TrackerAPI {

--- a/twake/backend/node/src/core/platform/services/tracker/index.ts
+++ b/twake/backend/node/src/core/platform/services/tracker/index.ts
@@ -5,6 +5,7 @@ import TrackerAPI from "./provider";
 import { localEventBus } from "../../framework/pubsub";
 import { IdentifyObjectType, TrackedEventType, TrackerConfiguration } from "./types";
 import { ResourceEventsPayload } from "../../../../utils/types";
+import { md5 } from "src/core/crypto";
 
 @Consumes([])
 export default class Tracker extends TwakeService<TrackerAPI> implements TrackerAPI {
@@ -108,7 +109,7 @@ export default class Tracker extends TwakeService<TrackerAPI> implements Tracker
   ): Promise<void> {
     const analiticsIdentity = {
       userId: identity.user?.allow_tracking ? identity.user.identity_provider_id : undefined,
-      anonymousId: "anonymous",
+      anonymousId: "anonymous-" + md5(identity.user.identity_provider_id),
       ...identity, //Fixme: right now we use this to send onboarding emails so user is not completely anonymous yet
     };
 

--- a/twake/backend/node/src/core/platform/services/tracker/index.ts
+++ b/twake/backend/node/src/core/platform/services/tracker/index.ts
@@ -108,8 +108,7 @@ export default class Tracker extends TwakeService<TrackerAPI> implements Tracker
     callback?: (err: Error) => void,
   ): Promise<void> {
     const analiticsIdentity = {
-      userId: identity.user?.allow_tracking ? identity.user.identity_provider_id : undefined,
-      anonymousId: `anonymous-${md5(identity.user.identity_provider_id)}`,
+      userId: identity.user?.allow_tracking ? identity.user.identity_provider_id : `anonymous-${md5(identity.user.identity_provider_id)}`,
       ...identity, //Fixme: right now we use this to send onboarding emails so user is not completely anonymous yet
     };
 

--- a/twake/backend/node/src/core/platform/services/tracker/index.ts
+++ b/twake/backend/node/src/core/platform/services/tracker/index.ts
@@ -109,7 +109,7 @@ export default class Tracker extends TwakeService<TrackerAPI> implements Tracker
   ): Promise<void> {
     const analiticsIdentity = {
       userId: identity.user?.allow_tracking ? identity.user.identity_provider_id : undefined,
-      anonymousId: "anonymous-" + md5(identity.user.identity_provider_id),
+      anonymousId: `anonymous-${md5(identity.user.identity_provider_id)}`,
       ...identity, //Fixme: right now we use this to send onboarding emails so user is not completely anonymous yet
     };
 


### PR DESCRIPTION
Our users can enable anonymous tracking for us to keep track of the platform usage. But currently all ids are "anonymous" (so we cannot count unique events).
Now we will have md5(userId) as anonymous id.