### PR TITLE
🛠 Fix start.sh errors

### DIFF
--- a/twake/start.sh
+++ b/twake/start.sh
@@ -6,6 +6,11 @@ else
   cp -nR ./default-configuration/* ./configuration
 fi
 
+data_folders=(./docker-data ./docker-data/documents ./docker-data/drive ./docker-data/drive-preview \
+			  ./docker-data/fpm ./docker-data/letsencrypt ./docker-data/logs ./docker-data/logs/nginx \
+			  ./docker-data/scylladb ./docker-data/uploads ./connectors)
+for folder in "${data_folders[@]}"; do if [ ! -d "$folder" ]; then mkdir "$folder"; fi; done #create mounted folders
+
 docker-compose pull
 
 docker-compose up -d scylladb rabbitmq


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The `start.sh` script doesn't correctly create the configuration folder and throws errors for missing folders.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This is tested on a Linux machine with the latest docker and docker-compose.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added the Signed-off-by statement at the end of my commit message.
