### PR TITLE
⚡️ #1734bis: Improve sideBar lazy loading 

### DIFF
--- a/twake/frontend/src/app/app.tsx
+++ b/twake/frontend/src/app/app.tsx
@@ -9,11 +9,14 @@ import RouterServices, { RouteType } from './services/RouterService';
 import ErrorBoundary from 'app/scenes/Error/ErrorBoundary';
 import InitService from './services/InitService';
 import UserContext from './state/recoil/integration/UserContext';
+import useTimeout from './services/hooks/useTimeout';
+import ApplicationLoader from './components/Loader/ApplicationLoader';
+import useRouterChannel from './state/recoil/hooks/useRouterChannel';
+import useRouterCompany from './state/recoil/hooks/useRouterCompany';
+import useRouterWorkspace from './state/recoil/hooks/useRouterWorkspace';
 
 import 'app/ui.scss';
 import 'app/theme.less';
-import useTimeout from './services/hooks/useTimeout';
-import ApplicationLoader from './components/Loader/ApplicationLoader';
 
 const delayMessage = 5000;
 
@@ -91,3 +94,10 @@ export default () => {
     </RecoilRoot>
   );
 };
+
+export const TestToto = () => {
+  const companyId = useRouterCompany()
+  const workspaceId = useRouterWorkspace()
+  const channelId = useRouterChannel()
+  return <div style={{position: "absolute",top:100, left:600, zIndex: 1000, width: "100px", height: "100px", background: "grey",pointerEvents: "none" }}> {channelId} </div>
+}

--- a/twake/frontend/src/app/app.tsx
+++ b/twake/frontend/src/app/app.tsx
@@ -11,9 +11,6 @@ import InitService from './services/InitService';
 import UserContext from './state/recoil/integration/UserContext';
 import useTimeout from './services/hooks/useTimeout';
 import ApplicationLoader from './components/Loader/ApplicationLoader';
-import useRouterChannel from './state/recoil/hooks/useRouterChannel';
-import useRouterCompany from './state/recoil/hooks/useRouterCompany';
-import useRouterWorkspace from './state/recoil/hooks/useRouterWorkspace';
 
 import 'app/ui.scss';
 import 'app/theme.less';
@@ -59,22 +56,22 @@ export default () => {
       <Integration>
         <Router history={RouterServices.history}>
           <Switch>
-            {RouterServices.routes.map((route: RouteType, index: number) =>
+            {RouterServices.routes.map((route: RouteType, index: number) => (
               <Route
                 key={`${route.key}_${index}`}
                 exact={route.exact ? route.exact : false}
                 path={route.path}
                 component={() =>
-                  route.options?.withErrorBoundary
-                  ?
-                  <ErrorBoundary key={route.key}>
-                    <route.component />
-                  </ErrorBoundary>
-                  :
-                  <route.component key={route.key} />
+                  route.options?.withErrorBoundary ? (
+                    <ErrorBoundary key={route.key}>
+                      <route.component />
+                    </ErrorBoundary>
+                  ) : (
+                    <route.component key={route.key} />
+                  )
                 }
               />
-            )}
+            ))}
             {
               <Route
                 path="/"
@@ -94,10 +91,3 @@ export default () => {
     </RecoilRoot>
   );
 };
-
-export const TestToto = () => {
-  const companyId = useRouterCompany()
-  const workspaceId = useRouterWorkspace()
-  const channelId = useRouterChannel()
-  return <div style={{position: "absolute",top:100, left:600, zIndex: 1000, width: "100px", height: "100px", background: "grey",pointerEvents: "none" }}> {channelId} </div>
-}

--- a/twake/frontend/src/app/scenes/Client/ChannelsBar/ChannelsApps/ChannelsApps.tsx
+++ b/twake/frontend/src/app/scenes/Client/ChannelsBar/ChannelsApps/ChannelsApps.tsx
@@ -4,10 +4,7 @@ import Collections from 'app/services/Depreciated/Collections/Collections.js';
 import Languages from 'services/languages/languages';
 import Workspaces from 'services/workspaces/workspaces.js';
 import WorkspacesApps from 'services/workspaces/workspaces_apps.js';
-import UserService from 'services/user/UserService';
 import ChannelUI from 'app/scenes/Client/ChannelsBar/Parts/Channel/Channel';
-import ChannelsBarService from 'app/services/channels/ChannelsBarService';
-import AccessRightsService from 'app/services/AccessRightsService';
 import { useCompanyApplications } from 'app/state/recoil/hooks/useCompanyApplications';
 import RouterService from 'app/services/RouterService';
 

--- a/twake/frontend/src/app/scenes/Client/ChannelsBar/ChannelsBar.scss
+++ b/twake/frontend/src/app/scenes/Client/ChannelsBar/ChannelsBar.scss
@@ -97,10 +97,17 @@
 
   .applications_channels_loader {
     margin-top: 4px;
+    margin-bottom: 12px;
+    .ant-skeleton > .ant-skeleton-content > .ant-skeleton-paragraph > li {
+      border-radius: var(--border-radius-large);
+    }
   }
   .channels_loader {
     .ant-skeleton > .ant-skeleton-content > .ant-skeleton-title {
-      margin-top: 24px;
+      border-radius: var(--border-radius-large);
+    }
+    .ant-skeleton > .ant-skeleton-content > .ant-skeleton-paragraph > li {
+      border-radius: var(--border-radius-large);
     }
   }
 }

--- a/twake/frontend/src/app/scenes/Client/ChannelsBar/ChannelsBar.scss
+++ b/twake/frontend/src/app/scenes/Client/ChannelsBar/ChannelsBar.scss
@@ -89,6 +89,22 @@
   }
 }
 
+.channels_view_loader {
+  background: var(--grey-background);
+  width: 220px;
+  padding-top: 16px;
+  border-radius: var(--border-radius-base) 0 0 8px;
+
+  .applications_channels_loader {
+    margin-top: 4px;
+  }
+  .channels_loader {
+    .ant-skeleton > .ant-skeleton-content > .ant-skeleton-title {
+      margin-top: 24px;
+    }
+  }
+}
+
 .loading_render {
   .channel_small_text {
     display: none;

--- a/twake/frontend/src/app/scenes/Client/ChannelsBar/ChannelsBar.scss
+++ b/twake/frontend/src/app/scenes/Client/ChannelsBar/ChannelsBar.scss
@@ -98,17 +98,6 @@
   .applications_channels_loader {
     margin-top: 4px;
     margin-bottom: 12px;
-    .ant-skeleton > .ant-skeleton-content > .ant-skeleton-paragraph > li {
-      border-radius: var(--border-radius-large);
-    }
-  }
-  .channels_loader {
-    .ant-skeleton > .ant-skeleton-content > .ant-skeleton-title {
-      border-radius: var(--border-radius-large);
-    }
-    .ant-skeleton > .ant-skeleton-content > .ant-skeleton-paragraph > li {
-      border-radius: var(--border-radius-large);
-    }
   }
 }
 

--- a/twake/frontend/src/app/scenes/Client/ChannelsBar/ChannelsBar.tsx
+++ b/twake/frontend/src/app/scenes/Client/ChannelsBar/ChannelsBar.tsx
@@ -118,15 +118,9 @@ export const ChannelLoading = () => {
       <div className="applications_channels_loader small-x-margin">
         <Skeleton title={false} paragraph={{ rows: 3, width: '100%' }} />
       </div>
-      <div className="channels_loader small-x-margin">
-        <Skeleton
-          title={{ style: { background: '#DFDFDF' }, width: '50%' }}
-          paragraph={{ rows: 4, width: '100%' }}
-        />
-        <Skeleton
-          title={{ style: { background: '#DFDFDF' }, width: '50%' }}
-          paragraph={{ rows: 4, width: '100%' }}
-        />
+      <div className="small-x-margin">
+        <Skeleton title={{ width: '50%' }} paragraph={{ rows: 4, width: '100%' }} />
+        <Skeleton title={{ width: '50%' }} paragraph={{ rows: 4, width: '100%' }} />
       </div>
     </div>
   );

--- a/twake/frontend/src/app/scenes/Client/ChannelsBar/ChannelsBar.tsx
+++ b/twake/frontend/src/app/scenes/Client/ChannelsBar/ChannelsBar.tsx
@@ -25,7 +25,7 @@ import './ChannelsBar.scss';
 
 
 
-const LoadingChannels = () => {
+export const LoadingChannels = () => {
   return (
     <div style={{ paddingTop: 8 }}>
       <div className="channel" />

--- a/twake/frontend/src/app/scenes/Client/ChannelsBar/ChannelsBar.tsx
+++ b/twake/frontend/src/app/scenes/Client/ChannelsBar/ChannelsBar.tsx
@@ -1,11 +1,11 @@
 // eslint-disable-next-line @typescript-eslint/no-use-before-define
-import React, { useEffect } from 'react';
+import React, { Suspense, useEffect } from 'react';
 import classNames from 'classnames';
 import PerfectScrollbar from 'react-perfect-scrollbar';
-import { Layout } from 'antd';
+import { Layout, Skeleton } from 'antd';
 
 import CurrentUser from './Parts/CurrentUser/CurrentUser';
-import { CompanyApplications } from './ChannelsApps/ChannelsApps';
+import { CompanyApplications} from './ChannelsApps/ChannelsApps';
 import ChannelsWorkspace from './ChannelsWorkspace/ChannelsWorkspace';
 import ChannelsUser from './ChannelsUser/ChannelsUser';
 import Footer from './Parts/Footer.js';
@@ -20,30 +20,17 @@ import ChannelsBarService from 'app/services/channels/ChannelsBarService';
 import AccessRightsService from 'app/services/AccessRightsService';
 import useRouterCompany from 'app/state/recoil/hooks/useRouterCompany';
 import useRouterWorkspace from 'app/state/recoil/hooks/useRouterWorkspace';
+import { LoadingCompany } from './Parts/CurrentUser/CompanyHeader/CompanyHeader';
 
 import './ChannelsBar.scss';
 
-
-
 export const LoadingChannels = () => {
   return (
-    <div style={{ paddingTop: 8 }}>
-      <div className="channel" />
-      <div className="channel" />
-      <div className="channel" />
-      <div className="channel_category" />
-      <div className="channel" />
-      <div className="channel" />
-      <div className="channel_category" />
-      <div className="channel" />
-      <div className="channel" />
-      <div className="channel" />
-      <div className="channel" />
-      <div className="channel_category" />
-      <div className="channel" />
-      <div className="channel" />
-      <div className="channel" />
-    </div>
+    <Layout.Sider theme="light" width={220} className={classNames('channels_view_loading')} style={{ height: '100%', width: "90%", alignItems: 'center' }}>
+      <LoadingCompany />
+      <Channel_loading />
+    </Layout.Sider> 
+    
   );
 };
 
@@ -52,9 +39,9 @@ export default () => {
   const workspaceId = useRouterWorkspace(); 
 
   //Need to be fix, here ready always == true
-  const ready = true || ChannelsBarService.useWatcher(() => {
+  const ready = ChannelsBarService.useWatcher(async () => {
     return (
-      ChannelsBarService.isReady(companyId, workspaceId) &&
+      await ChannelsBarService.isReady(companyId, workspaceId) &&
       //ChannelsBarService.isReady(companyId, workspaceId, ['applications']) &&
       ChannelsBarService.isReady(companyId, 'direct')
     );
@@ -100,24 +87,37 @@ export default () => {
       <CurrentUser />
 
       {!ready && <LoadingChannels />}
-
-      <ScrollWithHiddenComponents
-        disabled={!ready}
-        tag="channel_bar_component"
-        scrollTopComponent={<HiddenNotificationsButton position="top" type="important" />}
-        scrollBottomComponent={<HiddenNotificationsButton position="bottom" type="important" />}
-      >
-        <PerfectScrollbar options={{ suppressScrollX: true }}>
-          <React.Suspense fallback={<></>}>
-            <CompanyApplications companyId={companyId} />
-          </React.Suspense>
-          <ChannelsWorkspace key={`workspace_chans_${workspaceId}`} />
-          <ChannelsUser key={companyId} />
-          {AccessRightsService.hasLevel(workspaceId, 'moderator') &&
-            Workspaces.getCurrentWorkspace().stats.total_members <= 5 && <AddUserButton />}
-        </PerfectScrollbar>
-      </ScrollWithHiddenComponents>
-      <Footer />
+        <ScrollWithHiddenComponents
+          disabled={!ready}
+          tag="channel_bar_component"
+          scrollTopComponent={<HiddenNotificationsButton position="top" type="important" />}
+          scrollBottomComponent={<HiddenNotificationsButton position="bottom" type="important" />}
+        >
+          <PerfectScrollbar options={{ suppressScrollX: true }}>
+            <Suspense fallback={<></>}>
+              <CompanyApplications companyId={companyId} />
+            </Suspense>
+            <ChannelsWorkspace key={`workspace_chans_${workspaceId}`} />
+            <ChannelsUser key={companyId} />
+            {AccessRightsService.hasLevel(workspaceId, 'moderator') &&
+              Workspaces.getCurrentWorkspace().stats.total_members <= 5 && <AddUserButton />}
+          </PerfectScrollbar>
+        </ScrollWithHiddenComponents>
+        <Footer />
     </Layout.Sider>
   );
 };
+
+export const Channel_loading = () => {
+  return (
+    <div className="channels_view_loader ">
+      <div className="applications_channels_loader small-x-margin">
+        <Skeleton title={false} paragraph={{rows : 3, width:["45%", "40%","50%"]}}/>
+      </div>
+      <div className="channels_loader small-x-margin">
+          <Skeleton title={{style:{height:22} , width:"45%"}} paragraph={{rows:4, width:["100%", "80%","90%","100"]}}/>
+          <Skeleton title={{style:{height:22}, width:"55%"}} paragraph={{rows:4, width:["60%", "90%","100%", "85%"]}}/>
+      </div>
+    </div>
+  );
+}

--- a/twake/frontend/src/app/scenes/Client/ChannelsBar/ChannelsBar.tsx
+++ b/twake/frontend/src/app/scenes/Client/ChannelsBar/ChannelsBar.tsx
@@ -20,36 +20,13 @@ import ChannelsBarService from 'app/services/channels/ChannelsBarService';
 import AccessRightsService from 'app/services/AccessRightsService';
 import useRouterCompany from 'app/state/recoil/hooks/useRouterCompany';
 import useRouterWorkspace from 'app/state/recoil/hooks/useRouterWorkspace';
+import { CompanyHeaderLoading } from './Parts/CurrentUser/CompanyHeader/CompanyHeader';
 
 import './ChannelsBar.scss';
-import { LoadingCompany } from './Parts/CurrentUser/CompanyHeader/CompanyHeader';
-
-const LoadingChannels = () => {
-  return (
-    <Layout.Sider
-      theme="light"
-      width={220}
-      className={classNames('channels_view_loading')}
-      style={{ height: '100%', width: '90%', alignItems: 'center' }}
-    >
-      <LoadingCompany />
-      <ChannelLoading />
-    </Layout.Sider>
-  );
-};
 
 export default () => {
   const companyId = useRouterCompany();
   const workspaceId = useRouterWorkspace();
-
-  //Need to be fix, here ready always == true
-  const ready = ChannelsBarService.useWatcher(async () => {
-    return (
-      (await ChannelsBarService.isReady(companyId, workspaceId)) &&
-      //ChannelsBarService.isReady(companyId, workspaceId, ['applications']) &&
-      ChannelsBarService.isReady(companyId, 'direct')
-    );
-  });
 
   useEffect(() => {
     const openWorkspaceChannelList: ShortcutType = {
@@ -82,17 +59,12 @@ export default () => {
     <Layout.Sider
       theme="light"
       width={220}
-      className={classNames('channels_view', {
-        loading: !ready,
-        loading_render: !ready,
-      })}
+      className={classNames('channels_view', {})}
       style={{ height: '100%' }}
     >
       <CurrentUser />
 
-      {!ready && <LoadingChannels />}
       <ScrollWithHiddenComponents
-        disabled={!ready}
         tag="channel_bar_component"
         scrollTopComponent={<HiddenNotificationsButton position="top" type="important" />}
         scrollBottomComponent={<HiddenNotificationsButton position="bottom" type="important" />}
@@ -108,6 +80,20 @@ export default () => {
         </PerfectScrollbar>
       </ScrollWithHiddenComponents>
       <Footer />
+    </Layout.Sider>
+  );
+};
+
+export const LoadingChannelBar = () => {
+  return (
+    <Layout.Sider
+      theme="light"
+      width={220}
+      className={classNames('channels_view_loading')}
+      style={{ height: '100%', width: '90%', alignItems: 'center' }}
+    >
+      <CompanyHeaderLoading />
+      <ChannelLoading />
     </Layout.Sider>
   );
 };

--- a/twake/frontend/src/app/scenes/Client/ChannelsBar/ChannelsBar.tsx
+++ b/twake/frontend/src/app/scenes/Client/ChannelsBar/ChannelsBar.tsx
@@ -5,7 +5,7 @@ import PerfectScrollbar from 'react-perfect-scrollbar';
 import { Layout, Skeleton } from 'antd';
 
 import CurrentUser from './Parts/CurrentUser/CurrentUser';
-import { CompanyApplications} from './ChannelsApps/ChannelsApps';
+import { CompanyApplications } from './ChannelsApps/ChannelsApps';
 import ChannelsWorkspace from './ChannelsWorkspace/ChannelsWorkspace';
 import ChannelsUser from './ChannelsUser/ChannelsUser';
 import Footer from './Parts/Footer.js';
@@ -26,22 +26,26 @@ import './ChannelsBar.scss';
 
 export const LoadingChannels = () => {
   return (
-    <Layout.Sider theme="light" width={220} className={classNames('channels_view_loading')} style={{ height: '100%', width: "90%", alignItems: 'center' }}>
+    <Layout.Sider
+      theme="light"
+      width={220}
+      className={classNames('channels_view_loading')}
+      style={{ height: '100%', width: '90%', alignItems: 'center' }}
+    >
       <LoadingCompany />
-      <Channel_loading />
-    </Layout.Sider> 
-    
+      <ChannelLoading />
+    </Layout.Sider>
   );
 };
 
 export default () => {
   const companyId = useRouterCompany();
-  const workspaceId = useRouterWorkspace(); 
+  const workspaceId = useRouterWorkspace();
 
   //Need to be fix, here ready always == true
   const ready = ChannelsBarService.useWatcher(async () => {
     return (
-      await ChannelsBarService.isReady(companyId, workspaceId) &&
+      (await ChannelsBarService.isReady(companyId, workspaceId)) &&
       //ChannelsBarService.isReady(companyId, workspaceId, ['applications']) &&
       ChannelsBarService.isReady(companyId, 'direct')
     );
@@ -87,37 +91,43 @@ export default () => {
       <CurrentUser />
 
       {!ready && <LoadingChannels />}
-        <ScrollWithHiddenComponents
-          disabled={!ready}
-          tag="channel_bar_component"
-          scrollTopComponent={<HiddenNotificationsButton position="top" type="important" />}
-          scrollBottomComponent={<HiddenNotificationsButton position="bottom" type="important" />}
-        >
-          <PerfectScrollbar options={{ suppressScrollX: true }}>
-            <Suspense fallback={<></>}>
-              <CompanyApplications companyId={companyId} />
-            </Suspense>
-            <ChannelsWorkspace key={`workspace_chans_${workspaceId}`} />
-            <ChannelsUser key={companyId} />
-            {AccessRightsService.hasLevel(workspaceId, 'moderator') &&
-              Workspaces.getCurrentWorkspace().stats.total_members <= 5 && <AddUserButton />}
-          </PerfectScrollbar>
-        </ScrollWithHiddenComponents>
-        <Footer />
+      <ScrollWithHiddenComponents
+        disabled={!ready}
+        tag="channel_bar_component"
+        scrollTopComponent={<HiddenNotificationsButton position="top" type="important" />}
+        scrollBottomComponent={<HiddenNotificationsButton position="bottom" type="important" />}
+      >
+        <PerfectScrollbar options={{ suppressScrollX: true }}>
+          <Suspense fallback={<></>}>
+            <CompanyApplications companyId={companyId} />
+          </Suspense>
+          <ChannelsWorkspace key={`workspace_chans_${workspaceId}`} />
+          <ChannelsUser key={companyId} />
+          {AccessRightsService.hasLevel(workspaceId, 'moderator') &&
+            Workspaces.getCurrentWorkspace().stats.total_members <= 5 && <AddUserButton />}
+        </PerfectScrollbar>
+      </ScrollWithHiddenComponents>
+      <Footer />
     </Layout.Sider>
   );
 };
 
-export const Channel_loading = () => {
+export const ChannelLoading = () => {
   return (
     <div className="channels_view_loader ">
       <div className="applications_channels_loader small-x-margin">
-        <Skeleton title={false} paragraph={{rows : 3, width:["45%", "40%","50%"]}}/>
+        <Skeleton title={false} paragraph={{ rows: 3, width: '100%' }} />
       </div>
       <div className="channels_loader small-x-margin">
-          <Skeleton title={{style:{height:22} , width:"45%"}} paragraph={{rows:4, width:["100%", "80%","90%","100"]}}/>
-          <Skeleton title={{style:{height:22}, width:"55%"}} paragraph={{rows:4, width:["60%", "90%","100%", "85%"]}}/>
+        <Skeleton
+          title={{ style: { background: '#DFDFDF' }, width: '50%' }}
+          paragraph={{ rows: 4, width: '100%' }}
+        />
+        <Skeleton
+          title={{ style: { background: '#DFDFDF' }, width: '50%' }}
+          paragraph={{ rows: 4, width: '100%' }}
+        />
       </div>
     </div>
   );
-}
+};

--- a/twake/frontend/src/app/scenes/Client/ChannelsBar/Parts/CurrentUser/CompanyHeader/CompanyHeader.scss
+++ b/twake/frontend/src/app/scenes/Client/ChannelsBar/Parts/CurrentUser/CompanyHeader/CompanyHeader.scss
@@ -158,31 +158,24 @@
   }
 }
 
-.current-company-header-loader {
+.current_company_header_loader {
   display: flex;
-  margin-left: 20px;
-  margin-right: 12px;
   width: auto;
   box-sizing: border-box;
 
-  .current-company-loader {
+  .current_company_loader {
     flex: 1;
     overflow: hidden;
     height: 48px;
+    .ant-skeleton > .ant-skeleton-content {
+      height: 48px;
+    }
 
-    .user-info-loader {
-      align-items: center;
-      background-color: var(--grey-dark);
-      background-size: cover;
-      background-position: center;
-      opacity: 1;
-      height: 12px;
-      margin-top: -10%;
-      margin-right: 20%;
-      margin-left: 20%;
-      overflow: hidden;
-      white-space: nowrap;
-      border-radius: var(--border-radius-base);
+    .ant-skeleton > .ant-skeleton-content > .ant-skeleton-title {
+      border-radius: var(--border-radius-large);
+    }
+    .ant-skeleton > .ant-skeleton-content > .ant-skeleton-paragraph > li {
+      border-radius: var(--border-radius-large);
     }
   }
 }

--- a/twake/frontend/src/app/scenes/Client/ChannelsBar/Parts/CurrentUser/CompanyHeader/CompanyHeader.scss
+++ b/twake/frontend/src/app/scenes/Client/ChannelsBar/Parts/CurrentUser/CompanyHeader/CompanyHeader.scss
@@ -170,12 +170,5 @@
     .ant-skeleton > .ant-skeleton-content {
       height: 48px;
     }
-
-    .ant-skeleton > .ant-skeleton-content > .ant-skeleton-title {
-      border-radius: var(--border-radius-large);
-    }
-    .ant-skeleton > .ant-skeleton-content > .ant-skeleton-paragraph > li {
-      border-radius: var(--border-radius-large);
-    }
   }
 }

--- a/twake/frontend/src/app/scenes/Client/ChannelsBar/Parts/CurrentUser/CompanyHeader/CompanyHeader.scss
+++ b/twake/frontend/src/app/scenes/Client/ChannelsBar/Parts/CurrentUser/CompanyHeader/CompanyHeader.scss
@@ -157,3 +157,32 @@
     }
   }
 }
+
+.current-company-header-loader {
+  display: flex;
+  margin-left: 20px;
+  margin-right: 12px;
+  width: auto;
+  box-sizing: border-box;
+
+  .current-company-loader {
+    flex: 1;
+    overflow: hidden;
+    height: 48px;
+
+    .user-info-loader {
+      align-items: center;
+      background-color: var(--grey-dark);
+      background-size: cover;
+      background-position: center;
+      opacity: 1;
+      height: 12px;
+      margin-top: -10%;
+      margin-right: 20%;
+      margin-left: 20%;
+      overflow: hidden;
+      white-space: nowrap;
+      border-radius: var(--border-radius-base);
+    }
+  }
+}

--- a/twake/frontend/src/app/scenes/Client/ChannelsBar/Parts/CurrentUser/CompanyHeader/CompanyHeader.tsx
+++ b/twake/frontend/src/app/scenes/Client/ChannelsBar/Parts/CurrentUser/CompanyHeader/CompanyHeader.tsx
@@ -7,8 +7,6 @@ import Icon from 'components/Icon/Icon.js';
 import Emojione from 'components/Emojione/Emojione';
 import NotificationDelay from '../Notifications/NotificationDelay';
 import useCurrentUser from 'app/services/user/hooks/useCurrentUser';
-import { SkeletonTitleProps } from 'antd/lib/skeleton/Title';
-import { SkeletonParagraphProps } from 'antd/lib/skeleton/Paragraph';
 
 import './CompanyHeader.scss';
 

--- a/twake/frontend/src/app/scenes/Client/ChannelsBar/Parts/CurrentUser/CompanyHeader/CompanyHeader.tsx
+++ b/twake/frontend/src/app/scenes/Client/ChannelsBar/Parts/CurrentUser/CompanyHeader/CompanyHeader.tsx
@@ -54,10 +54,7 @@ export const LoadingCompany = () => {
   return (
     <div className="current_company_header_loader ">
       <div className="current_company_loader small-x-margin">
-        <Skeleton
-          title={{ style: { height: 22, background: '#DFDFDF' }, width: '50%' }}
-          paragraph={{ style: { background: '#DFDFDF' }, rows: 2 }}
-        />
+        <Skeleton title={{ style: { height: 22 }, width: '50%' }} />
       </div>
     </div>
   );

--- a/twake/frontend/src/app/scenes/Client/ChannelsBar/Parts/CurrentUser/CompanyHeader/CompanyHeader.tsx
+++ b/twake/frontend/src/app/scenes/Client/ChannelsBar/Parts/CurrentUser/CompanyHeader/CompanyHeader.tsx
@@ -1,11 +1,14 @@
 // eslint-disable-next-line @typescript-eslint/no-use-before-define
 import React from 'react';
+import { Skeleton } from 'antd';
 
 import UserService from 'services/user/UserService';
 import Icon from 'components/Icon/Icon.js';
 import Emojione from 'components/Emojione/Emojione';
 import NotificationDelay from '../Notifications/NotificationDelay';
 import useCurrentUser from 'app/services/user/hooks/useCurrentUser';
+import { SkeletonTitleProps } from 'antd/lib/skeleton/Title';
+import { SkeletonParagraphProps } from 'antd/lib/skeleton/Paragraph';
 
 import './CompanyHeader.scss';
 
@@ -44,6 +47,19 @@ export default (props: PropsType): JSX.Element => {
       </div>
       <div className="notifications">
         <NotificationDelay />
+      </div>
+    </div>
+  );
+};
+
+export const LoadingCompany = () => {
+  const workspace_name_loading : SkeletonTitleProps = {style: {height:28}, width: "40%"}
+  const user_mail_loading : SkeletonParagraphProps = {rows: 1, width: "100%"}
+  return (
+    <div className="current_company_header_loader ">
+      <div className="current_company_loader small-x-margin">
+        <Skeleton title={workspace_name_loading} paragraph={false}/>
+        <Skeleton title={false} paragraph={user_mail_loading}/>  
       </div>
     </div>
   );

--- a/twake/frontend/src/app/scenes/Client/ChannelsBar/Parts/CurrentUser/CompanyHeader/CompanyHeader.tsx
+++ b/twake/frontend/src/app/scenes/Client/ChannelsBar/Parts/CurrentUser/CompanyHeader/CompanyHeader.tsx
@@ -50,7 +50,7 @@ export default (props: PropsType): JSX.Element => {
   );
 };
 
-export const LoadingCompany = () => {
+export const CompanyHeaderLoading = () => {
   return (
     <div className="current_company_header_loader ">
       <div className="current_company_loader small-x-margin">

--- a/twake/frontend/src/app/scenes/Client/ChannelsBar/Parts/CurrentUser/CompanyHeader/CompanyHeader.tsx
+++ b/twake/frontend/src/app/scenes/Client/ChannelsBar/Parts/CurrentUser/CompanyHeader/CompanyHeader.tsx
@@ -35,7 +35,7 @@ export default (props: PropsType): JSX.Element => {
           </div>
         </div>
 
-        { user &&
+        {user && (
           <div className="user-info">
             {!!(user.status_icon || [])[0] && <Emojione type={user.status_icon![0]} />}
 
@@ -43,7 +43,7 @@ export default (props: PropsType): JSX.Element => {
               {UserService.getFullName(user)} ({user.email})
             </span>
           </div>
-        }
+        )}
       </div>
       <div className="notifications">
         <NotificationDelay />
@@ -53,13 +53,13 @@ export default (props: PropsType): JSX.Element => {
 };
 
 export const LoadingCompany = () => {
-  const workspace_name_loading : SkeletonTitleProps = {style: {height:28}, width: "40%"}
-  const user_mail_loading : SkeletonParagraphProps = {rows: 1, width: "100%"}
   return (
     <div className="current_company_header_loader ">
       <div className="current_company_loader small-x-margin">
-        <Skeleton title={workspace_name_loading} paragraph={false}/>
-        <Skeleton title={false} paragraph={user_mail_loading}/>  
+        <Skeleton
+          title={{ style: { height: 22, background: '#DFDFDF' }, width: '50%' }}
+          paragraph={{ style: { background: '#DFDFDF' }, rows: 2 }}
+        />
       </div>
     </div>
   );

--- a/twake/frontend/src/app/scenes/Client/Client.tsx
+++ b/twake/frontend/src/app/scenes/Client/Client.tsx
@@ -20,7 +20,7 @@ import ConnectionIndicator from 'components/ConnectionIndicator/ConnectionIndica
 import SearchPopup from 'components/SearchPopup/SearchPopup.js';
 import LoginService from 'app/services/login/LoginService';
 import NewVersionComponent from 'components/NewVersion/NewVersionComponent';
-import SideBars, { LoadingSidebar} from './SideBars';
+import SideBars, { LoadingSidebar } from './SideBars';
 import CompanyStatusComponent from 'app/components/OnBoarding/CompanyStatusComponent';
 import useCurrentUser from 'app/services/user/hooks/useCurrentUser';
 import useRouterCompany from 'app/state/recoil/hooks/useRouterCompany';
@@ -29,9 +29,8 @@ import useRouterWorkspace from 'app/state/recoil/hooks/useRouterWorkspace';
 import './Client.scss';
 
 export default React.memo((): JSX.Element => {
-  
   const companyId = useRouterCompany();
-  const workspaceId = useRouterWorkspace(); 
+  const workspaceId = useRouterWorkspace();
   const [menuIsOpen, setMenuIsOpen] = useState(false);
   const user = useCurrentUser();
 
@@ -72,13 +71,13 @@ export default React.memo((): JSX.Element => {
                   setMenuIsOpen(!collapsed);
                 }}
               >
-                <SideBars />              
+                <SideBars />
               </Layout.Sider>
             </Suspense>
-                  <MainView
-                    className={classNames({ collapsed: menuIsOpen })}
-                    key={`mainview-${companyId}-${workspaceId}`}
-                  />
+            <MainView
+              className={classNames({ collapsed: menuIsOpen })}
+              key={`mainview-${companyId}-${workspaceId}`}
+            />
           </Layout>
         </Layout>
       );
@@ -100,4 +99,3 @@ export default React.memo((): JSX.Element => {
     </>
   );
 });
-

--- a/twake/frontend/src/app/scenes/Client/Client.tsx
+++ b/twake/frontend/src/app/scenes/Client/Client.tsx
@@ -1,5 +1,5 @@
 // eslint-disable-next-line @typescript-eslint/no-use-before-define
-import React, { useEffect, useState } from 'react';
+import React, { Suspense, useEffect, useState } from 'react';
 import { Menu } from 'react-feather';
 import { Layout } from 'antd';
 import classNames from 'classnames';
@@ -20,7 +20,7 @@ import ConnectionIndicator from 'components/ConnectionIndicator/ConnectionIndica
 import SearchPopup from 'components/SearchPopup/SearchPopup.js';
 import LoginService from 'app/services/login/LoginService';
 import NewVersionComponent from 'components/NewVersion/NewVersionComponent';
-import SideBars from './SideBars';
+import SideBars, { LoadingSidebar} from './SideBars';
 import CompanyStatusComponent from 'app/components/OnBoarding/CompanyStatusComponent';
 import useCurrentUser from 'app/services/user/hooks/useCurrentUser';
 import useRouterCompany from 'app/state/recoil/hooks/useRouterCompany';
@@ -57,26 +57,28 @@ export default React.memo((): JSX.Element => {
           <NewVersionComponent />
           {companyId && workspaceId && <CompanyStatusComponent />}
           <Layout hasSider>
-            <Layout.Sider
-              trigger={<Menu size={16} />}
-              breakpoint="lg"
-              collapsedWidth="0"
-              theme="light"
-              width={290}
-              onCollapse={(collapsed, type) => {
-                if (type === 'responsive') {
-                  setMenuIsOpen(false);
-                  return;
-                }
-                setMenuIsOpen(!collapsed);
-              }}
-            >
-              <SideBars />
-            </Layout.Sider>
-            <MainView
-              className={classNames({ collapsed: menuIsOpen })}
-              key={`mainview-${companyId}-${workspaceId}`}
-            />
+            <Suspense fallback={<LoadingSidebar />}>
+              <Layout.Sider
+                trigger={<Menu size={16} />}
+                breakpoint="lg"
+                collapsedWidth="0"
+                theme="light"
+                width={290}
+                onCollapse={(collapsed, type) => {
+                  if (type === 'responsive') {
+                    setMenuIsOpen(false);
+                    return;
+                  }
+                  setMenuIsOpen(!collapsed);
+                }}
+              >
+                <SideBars />              
+              </Layout.Sider>
+            </Suspense>
+                  <MainView
+                    className={classNames({ collapsed: menuIsOpen })}
+                    key={`mainview-${companyId}-${workspaceId}`}
+                  />
           </Layout>
         </Layout>
       );

--- a/twake/frontend/src/app/scenes/Client/Client.tsx
+++ b/twake/frontend/src/app/scenes/Client/Client.tsx
@@ -56,24 +56,24 @@ export default React.memo((): JSX.Element => {
           <NewVersionComponent />
           {companyId && workspaceId && <CompanyStatusComponent />}
           <Layout hasSider>
-            <Suspense fallback={<LoadingSidebar />}>
-              <Layout.Sider
-                trigger={<Menu size={16} />}
-                breakpoint="lg"
-                collapsedWidth="0"
-                theme="light"
-                width={290}
-                onCollapse={(collapsed, type) => {
-                  if (type === 'responsive') {
-                    setMenuIsOpen(false);
-                    return;
-                  }
-                  setMenuIsOpen(!collapsed);
-                }}
-              >
+            <Layout.Sider
+              trigger={<Menu size={16} />}
+              breakpoint="lg"
+              collapsedWidth="0"
+              theme="light"
+              width={290}
+              onCollapse={(collapsed, type) => {
+                if (type === 'responsive') {
+                  setMenuIsOpen(false);
+                  return;
+                }
+                setMenuIsOpen(!collapsed);
+              }}
+            >
+              <Suspense fallback={<LoadingSidebar />}>
                 <SideBars />
-              </Layout.Sider>
-            </Suspense>
+              </Suspense>
+            </Layout.Sider>
             <MainView
               className={classNames({ collapsed: menuIsOpen })}
               key={`mainview-${companyId}-${workspaceId}`}

--- a/twake/frontend/src/app/scenes/Client/MainView/MainView.tsx
+++ b/twake/frontend/src/app/scenes/Client/MainView/MainView.tsx
@@ -15,21 +15,18 @@ import useRouterChannel from 'app/state/recoil/hooks/useRouterChannel';
 
 import './MainView.scss';
 
-
-
 type PropsType = {
   className?: string;
 };
 
 const MainView: FC<PropsType> = ({ className }) => {
-  
   const companyId = useRouterCompany();
   const workspaceId = useRouterWorkspace();
   const channelId = useRouterChannel();
 
-  const loaded = useWatcher(ChannelsBarService, () => {
+  const loaded = useWatcher(ChannelsBarService, async () => {
     return (
-      ChannelsBarService.isReady(companyId, workspaceId) &&
+      (await ChannelsBarService.isReady(companyId, workspaceId)) &&
       ChannelsBarService.isReady(companyId, 'direct')
     );
   });
@@ -44,7 +41,7 @@ const MainView: FC<PropsType> = ({ className }) => {
       {!!channelId && ready && (
         <>
           <AccountStatusComponent />
-          {companyId && <CompanyBillingBanner companyId={companyId || ""} />}
+          {companyId && <CompanyBillingBanner companyId={companyId || ''} />}
           <MainHeader />
           <MainContent />
         </>

--- a/twake/frontend/src/app/scenes/Client/SideBars.tsx
+++ b/twake/frontend/src/app/scenes/Client/SideBars.tsx
@@ -2,8 +2,8 @@
 import React from 'react';
 import { Layout } from 'antd';
 
-import ChannelsBar, { LoadingChannels } from './ChannelsBar/ChannelsBar';
-import WorkspacesBar, { LoadingWorkspace } from './WorkspacesBar/WorkspacesBar';
+import ChannelsBar, { LoadingChannelBar } from './ChannelsBar/ChannelsBar';
+import WorkspacesBar, { LoadingWorkspaceBar } from './WorkspacesBar/WorkspacesBar';
 
 import './WorkspacesBar/WorkspacesBar.scss';
 
@@ -19,8 +19,8 @@ export default () => {
 export const LoadingSidebar = () => {
   return (
     <Layout style={{ height: '100%' }}>
-      <LoadingWorkspace />
-      <LoadingChannels />
+      <LoadingWorkspaceBar />
+      <LoadingChannelBar />
     </Layout>
   );
 };

--- a/twake/frontend/src/app/scenes/Client/SideBars.tsx
+++ b/twake/frontend/src/app/scenes/Client/SideBars.tsx
@@ -5,27 +5,22 @@ import { Layout } from 'antd';
 import ChannelsBar, { LoadingChannels } from './ChannelsBar/ChannelsBar';
 import WorkspacesBar, { LoadingWorkspace } from './WorkspacesBar/WorkspacesBar';
 
-import "./WorkspacesBar/WorkspacesBar.scss"
-
-
-
+import './WorkspacesBar/WorkspacesBar.scss';
 
 export default () => {
   return (
-      <Layout style={{ height: '100%', backgroundColor: 'var(--secondary)' }}>
-          <WorkspacesBar key="workspacebar" />
-          <ChannelsBar key="channelbar" />
-      </Layout>
+    <Layout style={{ height: '100%', backgroundColor: 'var(--secondary)' }}>
+      <WorkspacesBar key="workspacebar" />
+      <ChannelsBar key="channelbar" />
+    </Layout>
   );
 };
 
-
 export const LoadingSidebar = () => {
   return (
-    <Layout style={{ height: '100%'}}>      
+    <Layout style={{ height: '100%' }}>
       <LoadingWorkspace />
       <LoadingChannels />
     </Layout>
-
   );
 };

--- a/twake/frontend/src/app/scenes/Client/SideBars.tsx
+++ b/twake/frontend/src/app/scenes/Client/SideBars.tsx
@@ -1,6 +1,5 @@
 // eslint-disable-next-line @typescript-eslint/no-use-before-define
 import React from 'react';
-import classNames from 'classnames';
 import { Layout } from 'antd';
 
 import ChannelsBar, { LoadingChannels } from './ChannelsBar/ChannelsBar';
@@ -23,11 +22,9 @@ export default () => {
 
 export const LoadingSidebar = () => {
   return (
-    <Layout>
+    <Layout style={{ height: '100%'}}>      
       <LoadingWorkspace />
-      <Layout.Sider theme="light" width={220} className={classNames('channels_view', {loading: true, loading_render: true, })} style={{ height: '100%' }}>
-        <LoadingChannels />
-      </Layout.Sider> 
+      <LoadingChannels />
     </Layout>
 
   );

--- a/twake/frontend/src/app/scenes/Client/SideBars.tsx
+++ b/twake/frontend/src/app/scenes/Client/SideBars.tsx
@@ -1,17 +1,34 @@
 // eslint-disable-next-line @typescript-eslint/no-use-before-define
-import React, { Suspense } from 'react';
+import React from 'react';
+import classNames from 'classnames';
 import { Layout } from 'antd';
 
-import ChannelsBar from './ChannelsBar/ChannelsBar';
-import WorkspacesBar from './WorkspacesBar/WorkspacesBar';
+import ChannelsBar, { LoadingChannels } from './ChannelsBar/ChannelsBar';
+import WorkspacesBar, { LoadingWorkspace } from './WorkspacesBar/WorkspacesBar';
+
+import "./WorkspacesBar/WorkspacesBar.scss"
+
+
+
 
 export default () => {
   return (
-    <Layout style={{ height: '100%', backgroundColor: 'var(--secondary)' }}>
-      <Suspense fallback={<Layout.Sider className={'workspaces_view'} width={70} />}>
-        <WorkspacesBar key="workspacebar" />
-      </Suspense>
-      <ChannelsBar key="channelbar" />
+      <Layout style={{ height: '100%', backgroundColor: 'var(--secondary)' }}>
+          <WorkspacesBar key="workspacebar" />
+          <ChannelsBar key="channelbar" />
+      </Layout>
+  );
+};
+
+
+export const LoadingSidebar = () => {
+  return (
+    <Layout>
+      <LoadingWorkspace />
+      <Layout.Sider theme="light" width={220} className={classNames('channels_view', {loading: true, loading_render: true, })} style={{ height: '100%' }}>
+        <LoadingChannels />
+      </Layout.Sider> 
     </Layout>
+
   );
 };

--- a/twake/frontend/src/app/scenes/Client/WorkspacesBar/Components/Workspace/WorkspaceIcon.tsx
+++ b/twake/frontend/src/app/scenes/Client/WorkspacesBar/Components/Workspace/WorkspaceIcon.tsx
@@ -37,7 +37,7 @@ export default (props: Props): JSX.Element => {
         }
         style={{ backgroundImage: addApiUrlIfNeeded(workspace.logo, true) }}
       >
-        {`${name}-`[0].toUpperCase()}
+        {workspace.name !== '' && `${name}-`[0].toUpperCase()}
         {unreadInWorkspace > 0 && <div className="notification_dot" />}
       </div>
       <div className="name">{name}</div>

--- a/twake/frontend/src/app/scenes/Client/WorkspacesBar/Components/Workspace/WorkspaceIcon.tsx
+++ b/twake/frontend/src/app/scenes/Client/WorkspacesBar/Components/Workspace/WorkspaceIcon.tsx
@@ -1,6 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-use-before-define
 import React from 'react';
 import classNames from 'classnames';
+import { Skeleton } from 'antd';
 
 import { NotificationResource } from 'app/models/Notification';
 import { Collection } from 'app/services/CollectionsReact/Collections';
@@ -44,3 +45,11 @@ export default (props: Props): JSX.Element => {
     </div>
   );
 };
+
+export const LoadingWorkspaceIcon = () => {
+  const size = 32; 
+  const shape = "square";
+  return (  
+    <Skeleton.Avatar size={size} shape={shape} />
+  );
+}

--- a/twake/frontend/src/app/scenes/Client/WorkspacesBar/Components/Workspace/WorkspaceIcon.tsx
+++ b/twake/frontend/src/app/scenes/Client/WorkspacesBar/Components/Workspace/WorkspaceIcon.tsx
@@ -12,30 +12,28 @@ type Props = {
   workspace: WorkspaceType;
   selected: boolean;
   onClick: () => void;
-}
+};
 
 export default (props: Props): JSX.Element => {
   const notificationsCollection = Collection.get('/notifications/v1/badges/', NotificationResource);
-  const unreadInWorkspace = notificationsCollection.useWatcher({ workspace_id: props.workspace.id }).length;
+  const unreadInWorkspace = notificationsCollection.useWatcher({
+    workspace_id: props.workspace.id,
+  }).length;
   const workspace = props.workspace || {};
   const name = workspace.mininame || workspace.name || '';
 
   return (
     <div
-      className={
-        classNames('workspace', {
-          'is_selected': props.selected,
-          'has_notifications': unreadInWorkspace > 0,
-        })
-      }
+      className={classNames('workspace', {
+        is_selected: props.selected,
+        has_notifications: unreadInWorkspace > 0,
+      })}
       onClick={props.onClick}
     >
       <div
-        className={
-          classNames('image', {
-            'has_image': !!workspace.logo,
-          })
-        }
+        className={classNames('image', {
+          has_image: !!workspace.logo,
+        })}
         style={{ backgroundImage: addApiUrlIfNeeded(workspace.logo, true) }}
       >
         {workspace.name !== '' && `${name}-`[0].toUpperCase()}
@@ -47,9 +45,7 @@ export default (props: Props): JSX.Element => {
 };
 
 export const LoadingWorkspaceIcon = () => {
-  const size = 32; 
-  const shape = "square";
-  return (  
-    <Skeleton.Avatar size={size} shape={shape} />
-  );
-}
+  const size = 32;
+  const shape = 'square';
+  return <Skeleton.Avatar size={size} shape={shape} style={{ marginBottom: 46 }} />;
+};

--- a/twake/frontend/src/app/scenes/Client/WorkspacesBar/WorkspacesBar.scss
+++ b/twake/frontend/src/app/scenes/Client/WorkspacesBar/WorkspacesBar.scss
@@ -18,6 +18,21 @@
     }
   }
 }
+
+.workpaces_view_loading {
+  padding-bottom: 30px;
+  div {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    .list {
+      position: relative;
+      height: 100%;
+      padding-top: 20px;
+    }
+  }
+}
+
 .no_workspaces {
   .workspaces_view {
     width: 0px !important;

--- a/twake/frontend/src/app/scenes/Client/WorkspacesBar/WorkspacesBar.tsx
+++ b/twake/frontend/src/app/scenes/Client/WorkspacesBar/WorkspacesBar.tsx
@@ -28,7 +28,7 @@ export default () => {
   );
 };
 
-export const LoadingWorkspace = () => {
+export const LoadingWorkspaceBar = () => {
   return (
     <Layout.Sider className={'workpaces_view_loading'} width={70}>
       <div className="list">

--- a/twake/frontend/src/app/scenes/Client/WorkspacesBar/WorkspacesBar.tsx
+++ b/twake/frontend/src/app/scenes/Client/WorkspacesBar/WorkspacesBar.tsx
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-use-before-define
 import React from 'react';
 import PerfectScrollbar from 'react-perfect-scrollbar';
-import { Layout } from 'antd';
+import { Layout, Skeleton } from 'antd';
 
 import { WorkspaceType } from 'app/models/Workspace';
 import Group from './Components/Group/Group';
@@ -15,17 +15,15 @@ import './WorkspacesBar.scss';
 export default () => {
   const companyId = useRouterCompany();
   const [workspaces] = useCompanyWorkspaces(companyId);
-  
+
   return (
     <Layout.Sider className={'workspaces_view'} width={70}>
       <PerfectScrollbar component="div" className="list">
         {workspaces.map((ws: WorkspaceType) => (
-          
-          <Workspace key={ws.id} workspace={ws}/>
-          
+          <Workspace key={ws.id} workspace={ws} />
         ))}
       </PerfectScrollbar>
-      <Group/>
+      <Group />
     </Layout.Sider>
   );
 };
@@ -34,11 +32,10 @@ export const LoadingWorkspace = () => {
   return (
     <Layout.Sider className={'workpaces_view_loading'} width={70}>
       <div className="list">
-        <LoadingWorkspaceIcon/>
+        <LoadingWorkspaceIcon />
+        <LoadingWorkspaceIcon />
       </div>
-      <LoadingWorkspaceIcon />
-      
+      <Skeleton.Avatar size={32} shape={'square'} style={{ marginBottom: 4 }} />
     </Layout.Sider>
   );
-}
-
+};

--- a/twake/frontend/src/app/scenes/Client/WorkspacesBar/WorkspacesBar.tsx
+++ b/twake/frontend/src/app/scenes/Client/WorkspacesBar/WorkspacesBar.tsx
@@ -30,3 +30,10 @@ export default () => {
   );
 };
 
+export const LoadingWorkspace = () => {
+  return (
+  <Layout.Sider className={'workspaces_view'} width={70}>
+  </Layout.Sider>
+  );
+}
+

--- a/twake/frontend/src/app/scenes/Client/WorkspacesBar/WorkspacesBar.tsx
+++ b/twake/frontend/src/app/scenes/Client/WorkspacesBar/WorkspacesBar.tsx
@@ -8,10 +8,9 @@ import Group from './Components/Group/Group';
 import Workspace from './Components/Workspace/Workspace';
 import { useCompanyWorkspaces } from 'app/state/recoil/hooks/useCompanyWorkspaces';
 import useRouterCompany from 'app/state/recoil/hooks/useRouterCompany';
-import WorkspaceIcon from './Components/Workspace/WorkspaceIcon';
+import { LoadingWorkspaceIcon } from './Components/Workspace/WorkspaceIcon';
 
 import './WorkspacesBar.scss';
-
 
 export default () => {
   const companyId = useRouterCompany();
@@ -32,30 +31,14 @@ export default () => {
 };
 
 export const LoadingWorkspace = () => {
-  const mockdate = new Date(0);
   return (
-  <Layout.Sider className={'workspaces_view'} width={70}>
-    <PerfectScrollbar component="div" className="list">
-      <WorkspaceIcon
-        workspace={{
-          id: '',
-          company_id: '',
-          archived: false,
-          default: false,
-          name: '',
-          mininame: undefined,
-          logo: '',
-          role: '',
-          stats: {
-            created_at:  mockdate,
-            total_members: 0
-          }
-        }}
-        selected={false}
-        onClick={() => null}
-      />
-    </PerfectScrollbar>
-  </Layout.Sider>
+    <Layout.Sider className={'workpaces_view_loading'} width={70}>
+      <div className="list">
+        <LoadingWorkspaceIcon/>
+      </div>
+      <LoadingWorkspaceIcon />
+      
+    </Layout.Sider>
   );
 }
 

--- a/twake/frontend/src/app/scenes/Client/WorkspacesBar/WorkspacesBar.tsx
+++ b/twake/frontend/src/app/scenes/Client/WorkspacesBar/WorkspacesBar.tsx
@@ -8,6 +8,7 @@ import Group from './Components/Group/Group';
 import Workspace from './Components/Workspace/Workspace';
 import { useCompanyWorkspaces } from 'app/state/recoil/hooks/useCompanyWorkspaces';
 import useRouterCompany from 'app/state/recoil/hooks/useRouterCompany';
+import WorkspaceIcon from './Components/Workspace/WorkspaceIcon';
 
 import './WorkspacesBar.scss';
 
@@ -31,8 +32,29 @@ export default () => {
 };
 
 export const LoadingWorkspace = () => {
+  const mockdate = new Date(0);
   return (
   <Layout.Sider className={'workspaces_view'} width={70}>
+    <PerfectScrollbar component="div" className="list">
+      <WorkspaceIcon
+        workspace={{
+          id: '',
+          company_id: '',
+          archived: false,
+          default: false,
+          name: '',
+          mininame: undefined,
+          logo: '',
+          role: '',
+          stats: {
+            created_at:  mockdate,
+            total_members: 0
+          }
+        }}
+        selected={false}
+        onClick={() => null}
+      />
+    </PerfectScrollbar>
   </Layout.Sider>
   );
 }

--- a/twake/frontend/src/app/theme.less
+++ b/twake/frontend/src/app/theme.less
@@ -455,3 +455,9 @@ h4.ant-typography,
 .ant-table {
   font-size: @font-size-small !important;
 }
+
+// --- ant-skeleton --- //
+//ant-skeleton-avatar
+.ant-skeleton-avatar-square {
+  border-radius: @border-radius-base;
+}

--- a/twake/frontend/src/app/theme.less
+++ b/twake/frontend/src/app/theme.less
@@ -33,6 +33,7 @@
 @success: #04aa11;
 @warning: #ff8607;
 @white: #fff;
+@lazy-backgound: #dfdfdf;
 
 /*
 // Preparation of dark theme
@@ -92,6 +93,7 @@
   --secondary: @secondary;
   --white: @white;
   --warning: @warning;
+  --lazy-backgroud: @lazy-backgound;
 }
 
 // --- ant-colors --- //
@@ -460,4 +462,13 @@ h4.ant-typography,
 //ant-skeleton-avatar
 .ant-skeleton-avatar-square {
   border-radius: @border-radius-base;
+}
+
+.ant-skeleton-title {
+  background-color: #dfdfdf !important;
+}
+
+.ant-skeleton-title,
+.ant-skeleton-paragraph > li {
+  border-radius: var(--border-radius-large) !important;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The purpose of this PR is to create a new side bar for the lazy loading with ant design skeleton

## Description
<!--- Describe your changes in detail -->
This PR is about to change the order from rendering. For now order is Main view -> ChannelBar -> Workspace bar and with this PR the order will become Workspace -> ChannelBar -> Main view 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
This is an extension of issue #1734 : https://github.com/linagora/Twake/pull/1739

## Preview of the loading sidebar 
<img width="989" alt="loadingSidebar" src="https://user-images.githubusercontent.com/46565431/143065507-7ed193b1-707e-4e63-b054-dd6c04ed23ce.png">

