### PR TITLE
⚡️ #1763bis:  Convert tab bar from ant design components to homemade components

### DIFF
--- a/twake/frontend/src/app/scenes/Client/MainView/Tabs/DefaultChannelTab.tsx
+++ b/twake/frontend/src/app/scenes/Client/MainView/Tabs/DefaultChannelTab.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import classNames from 'classnames';
 import RouterServices from 'app/services/RouterService';
 import WorkspacesApps from 'services/workspaces/workspaces_apps.js';
 import Menu from 'components/Menus/Menu.js';
@@ -63,9 +64,10 @@ export default ({ selected }: { selected: boolean }): JSX.Element => {
 
   return (
     <span
-      className={
-        selected ? 'tab-component-selected align-items-center' : 'tab-component align-items-center'
-      }
+      className={classNames({
+        'tab-component-selected align-items-center': selected,
+        'tab-component align-items-center': !selected,
+      })}
       onClick={() => {
         const route: string = RouterServices.generateRouteFromState({
           tabId: '',

--- a/twake/frontend/src/app/scenes/Client/MainView/Tabs/DefaultChannelTab.tsx
+++ b/twake/frontend/src/app/scenes/Client/MainView/Tabs/DefaultChannelTab.tsx
@@ -63,7 +63,9 @@ export default ({ selected }: { selected: boolean }): JSX.Element => {
 
   return (
     <span
-      className="align-items-center"
+      className={
+        selected ? 'tab-component-selected align-items-center' : 'tab-component align-items-center'
+      }
       onClick={() => {
         const route: string = RouterServices.generateRouteFromState({
           tabId: '',
@@ -73,7 +75,9 @@ export default ({ selected }: { selected: boolean }): JSX.Element => {
     >
       <MessageCircle size={14} className="small-right-margin" />
 
-      <span className="small-right-margin">{Languages.t('scenes.app.mainview.discussion')}</span>
+      <span className="tab-name small-right-margin">
+        {Languages.t('scenes.app.mainview.discussion')}
+      </span>
 
       {!!selected && AccessRightsService.hasLevel(workspaceId, 'member') && (
         <Menu

--- a/twake/frontend/src/app/scenes/Client/MainView/Tabs/Tab.tsx
+++ b/twake/frontend/src/app/scenes/Client/MainView/Tabs/Tab.tsx
@@ -45,7 +45,9 @@ export default ({ selected, tabId, currentUserId }: PropsType): JSX.Element => {
 
   return (
     <span
-      className="align-items-center"
+      className={
+        selected ? 'tab-component-selected align-items-center' : 'tab-component align-items-center'
+      }
       onClick={() => {
         const route: string = RouterServices.generateRouteFromState({
           tabId: tab.id,
@@ -54,10 +56,8 @@ export default ({ selected, tabId, currentUserId }: PropsType): JSX.Element => {
       }}
     >
       {WorkspacesApps.getAppIconComponent(tab, { size: 14 })}
-      <span style={{ maxWidth: '108px', marginBottom: 0 }} className="tab-name small-right-margin">
-        {capitalize(tab.name)}
-      </span>
-      {tab.id === tabId && AccessRightsService.hasLevel(workspaceId, 'member') && (
+      <span className="tab-name small-right-margin">{capitalize(tab.name)}</span>
+      {selected && AccessRightsService.hasLevel(workspaceId, 'member') && (
         <Menu
           style={{ lineHeight: 0 }}
           menu={[

--- a/twake/frontend/src/app/scenes/Client/MainView/Tabs/Tab.tsx
+++ b/twake/frontend/src/app/scenes/Client/MainView/Tabs/Tab.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import classNames from 'classnames';
 import { TabType } from 'app/models/Tab';
 import RouterServices from 'app/services/RouterService';
 import TabsTemplateEditor from './TabsTemplateEditor';
@@ -45,9 +46,10 @@ export default ({ selected, tabId, currentUserId }: PropsType): JSX.Element => {
 
   return (
     <span
-      className={
-        selected ? 'tab-component-selected align-items-center' : 'tab-component align-items-center'
-      }
+      className={classNames({
+        'tab-component-selected align-items-center': selected,
+        'tab-component align-items-center': !selected,
+      })}
       onClick={() => {
         const route: string = RouterServices.generateRouteFromState({
           tabId: tab.id,

--- a/twake/frontend/src/app/scenes/Client/MainView/Tabs/Tabs.scss
+++ b/twake/frontend/src/app/scenes/Client/MainView/Tabs/Tabs.scss
@@ -6,6 +6,7 @@
 .main-view-tabs {
   height: 47px;
   margin-inline: 8px;
+  overflow: auto;
 
   .tab-component {
     cursor: pointer;
@@ -23,12 +24,9 @@
     margin-right: 8px;
     padding-inline: 8px;
     border-radius: 8px;
+    text-shadow: 0 0 0.25px currentColor;
     color: var(--primary);
     background-color: var(--primary-background);
-  }
-
-  .ant-tabs-tab {
-    margin-right: 8px !important;
   }
 
   .tab-name {
@@ -37,21 +35,18 @@
     overflow: hidden;
     max-width: 108px;
   }
-
   .add-tab-button {
-    vertical-align: top;
+    cursor: pointer;
     display: flex;
     align-items: center;
     justify-content: center;
     width: 24px;
     height: 24px;
-    line-height: 24px;
     border-radius: var(--border-radius-large);
-    background: var(--grey-background);
-    margin-left: -8px;
+    background-color: var(--grey-light);
 
     &:hover {
-      background-color: var(--grey-light);
+      background-color: var(--secondary-background);
       color: var(--grey-dark);
     }
   }

--- a/twake/frontend/src/app/scenes/Client/MainView/Tabs/Tabs.scss
+++ b/twake/frontend/src/app/scenes/Client/MainView/Tabs/Tabs.scss
@@ -2,52 +2,56 @@
   display: flex;
   align-items: center;
 }
-
-.main-view-tabs {
+.tabs-global-container {
+  width: 100%;
   height: 47px;
-  margin-inline: 8px;
   overflow: auto;
+  .main-view-tabs {
+    height: 47px;
+    margin-inline: 8px;
+    overflow: auto;
 
-  .tab-component {
-    cursor: pointer;
-    line-height: 31px;
-    margin-right: 8px;
-    padding-inline: 8px;
-    &:hover {
-      opacity: 0.8;
-      color: var(--primary);
+    .tab-component {
+      cursor: pointer;
+      line-height: 31px;
+      margin-right: 8px;
+      padding-inline: 8px;
+      &:hover {
+        opacity: 0.8;
+        color: var(--primary);
+      }
     }
-  }
-  .tab-component-selected {
-    cursor: pointer;
-    line-height: 31px;
-    margin-right: 8px;
-    padding-inline: 8px;
-    border-radius: 8px;
-    text-shadow: 0 0 0.25px currentColor;
-    color: var(--primary);
-    background-color: var(--primary-background);
-  }
+    .tab-component-selected {
+      cursor: pointer;
+      line-height: 31px;
+      margin-right: 8px;
+      padding-inline: 8px;
+      border-radius: 8px;
+      text-shadow: 0 0 0.25px currentColor;
+      color: var(--primary);
+      background-color: var(--primary-background);
+    }
 
-  .tab-name {
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    overflow: hidden;
-    max-width: 108px;
-  }
-  .add-tab-button {
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 24px;
-    height: 24px;
-    border-radius: var(--border-radius-large);
-    background-color: var(--grey-light);
+    .tab-name {
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      overflow: hidden;
+      max-width: 108px;
+    }
+    .add-tab-button {
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 24px;
+      height: 24px;
+      border-radius: var(--border-radius-large);
+      background-color: var(--grey-light);
 
-    &:hover {
-      background-color: var(--secondary-background);
-      color: var(--grey-dark);
+      &:hover {
+        background-color: var(--secondary-background);
+        color: var(--grey-dark);
+      }
     }
   }
 }

--- a/twake/frontend/src/app/scenes/Client/MainView/Tabs/Tabs.scss
+++ b/twake/frontend/src/app/scenes/Client/MainView/Tabs/Tabs.scss
@@ -5,9 +5,26 @@
 
 .main-view-tabs {
   height: 47px;
+  margin-inline: 8px;
 
-  .ant-tabs .ant-tabs-top {
-    line-height: 47px;
+  .tab-component {
+    cursor: pointer;
+    line-height: 31px;
+    margin-right: 8px;
+    padding-inline: 8px;
+    &:hover {
+      opacity: 0.8;
+      color: var(--primary);
+    }
+  }
+  .tab-component-selected {
+    cursor: pointer;
+    line-height: 31px;
+    margin-right: 8px;
+    padding-inline: 8px;
+    border-radius: 8px;
+    color: var(--primary);
+    background-color: var(--primary-background);
   }
 
   .ant-tabs-tab {
@@ -15,13 +32,10 @@
   }
 
   .tab-name {
-    &:hover {
-      opacity: 0.8;
-      color: var(--primary);
-    }
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
+    max-width: 108px;
   }
 
   .add-tab-button {

--- a/twake/frontend/src/app/scenes/Client/MainView/Tabs/Tabs.scss
+++ b/twake/frontend/src/app/scenes/Client/MainView/Tabs/Tabs.scss
@@ -46,10 +46,10 @@
       width: 24px;
       height: 24px;
       border-radius: var(--border-radius-large);
-      background-color: var(--grey-light);
+      background-color: var(--grey-background);
 
       &:hover {
-        background-color: var(--secondary-background);
+        background-color: var(--grey-light);
         color: var(--grey-dark);
       }
     }

--- a/twake/frontend/src/app/scenes/Client/MainView/Tabs/Tabs.tsx
+++ b/twake/frontend/src/app/scenes/Client/MainView/Tabs/Tabs.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Plus } from 'react-feather';
 import { TabType } from 'app/models/Tab';
-import { Button, Row, Tabs } from 'antd';
+import { Button } from 'antd';
 
 import TabsTemplateEditor from './TabsTemplateEditor';
 import ModalManager from 'app/components/Modal/ModalManager';
@@ -28,27 +28,23 @@ export default (): JSX.Element => {
   }
 
   return (
-    <Row align="middle" className="main-view-tabs" wrap={false}>
+    <div style={{ width: '100%', height: '47px', overflow: 'auto' }}>
       {tabsList.sort((a, b) => (a.order || '').localeCompare(b.order || '')) && (
-        <Tabs activeKey={tabId ? tabId : 'default'}>
-          <Tabs.TabPane tab={<DefaultChannelTab selected={!tabId} />} key="default" />
+        <span className="main-view-tabs align-items-center">
+          <DefaultChannelTab selected={!tabId} />
           {tabsList.map((tab: TabType) => {
             return (
               tab.id && (
-                <Tabs.TabPane
-                  tab={
-                    <Tab
-                      currentUserId={currentUser.id}
-                      selected={tabId === tab.id}
-                      tabId={tab.id}
-                    />
-                  }
+                <Tab
                   key={tab.id}
+                  currentUserId={currentUser.id}
+                  selected={tabId === tab.id}
+                  tabId={tab.id}
                 />
               )
             );
           })}
-        </Tabs>
+        </span>
       )}
       {AccessRightsService.hasLevel(workspaceId, 'member') && (
         <Button
@@ -69,6 +65,6 @@ export default (): JSX.Element => {
           icon={<Plus size={14} />}
         />
       )}
-    </Row>
+    </div>
   );
 };

--- a/twake/frontend/src/app/scenes/Client/MainView/Tabs/Tabs.tsx
+++ b/twake/frontend/src/app/scenes/Client/MainView/Tabs/Tabs.tsx
@@ -9,9 +9,9 @@ import DefaultChannelTab from 'app/scenes/Client/MainView/Tabs/DefaultChannelTab
 import Tab from 'app/scenes/Client/MainView/Tabs/Tab';
 import UserService from 'services/user/UserService';
 import useTabs from 'app/state/recoil/hooks/useTabs';
+import AccessRightsService from 'app/services/AccessRightsService';
 
 import './Tabs.scss';
-import AccessRightsService from 'app/services/AccessRightsService';
 
 export default (): JSX.Element => {
   const { workspaceId, tabId } = RouterServices.getStateFromRoute();
@@ -27,7 +27,7 @@ export default (): JSX.Element => {
   }
 
   return (
-    <span style={{ width: '100%', height: '47px', overflow: 'auto' }}>
+    <div className="tabs-global-container">
       {tabsList.sort((a, b) => (a.order || '').localeCompare(b.order || '')) && (
         <span className="main-view-tabs align-items-center">
           <DefaultChannelTab selected={!tabId} />
@@ -64,6 +64,6 @@ export default (): JSX.Element => {
           )}
         </span>
       )}
-    </span>
+    </div>
   );
 };

--- a/twake/frontend/src/app/scenes/Client/MainView/Tabs/Tabs.tsx
+++ b/twake/frontend/src/app/scenes/Client/MainView/Tabs/Tabs.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Plus } from 'react-feather';
 import { TabType } from 'app/models/Tab';
-import { Button } from 'antd';
 
 import TabsTemplateEditor from './TabsTemplateEditor';
 import ModalManager from 'app/components/Modal/ModalManager';
@@ -28,7 +27,7 @@ export default (): JSX.Element => {
   }
 
   return (
-    <div style={{ width: '100%', height: '47px', overflow: 'auto' }}>
+    <span style={{ width: '100%', height: '47px', overflow: 'auto' }}>
       {tabsList.sort((a, b) => (a.order || '').localeCompare(b.order || '')) && (
         <span className="main-view-tabs align-items-center">
           <DefaultChannelTab selected={!tabId} />
@@ -44,27 +43,27 @@ export default (): JSX.Element => {
               )
             );
           })}
+          {AccessRightsService.hasLevel(workspaceId, 'member') && (
+            <div
+              className="add-tab-button"
+              onClick={() => {
+                return ModalManager.open(
+                  <TabsTemplateEditor
+                    currentUserId={currentUser.id}
+                    onChangeTabs={(item: TabType) => save(item)}
+                  />,
+                  {
+                    position: 'center',
+                    size: { width: '500px', minHeight: '329px' },
+                  },
+                );
+              }}
+            >
+              <Plus size={14} />
+            </div>
+          )}
         </span>
       )}
-      {AccessRightsService.hasLevel(workspaceId, 'member') && (
-        <Button
-          className="add-tab-button"
-          type="text"
-          onClick={() => {
-            return ModalManager.open(
-              <TabsTemplateEditor
-                currentUserId={currentUser.id}
-                onChangeTabs={(item: TabType) => save(item)}
-              />,
-              {
-                position: 'center',
-                size: { width: '500px', minHeight: '329px' },
-              },
-            );
-          }}
-          icon={<Plus size={14} />}
-        />
-      )}
-    </div>
+    </span>
   );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
In Twake the tabBar is really slow due to the use of ant design with a lot of over writing to make them match the Twake use of tabs

## Description
<!--- Describe your changes in detail -->
Create new components for the tab not using ant design anymore in purpose to make Twake faster 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/linagora/Twake/issues/1763

