### PR TITLE
#1820 Fix user status in message header component

### DIFF
--- a/twake/frontend/src/app/scenes/Apps/Messages/Message/Parts/MessageHeader.tsx
+++ b/twake/frontend/src/app/scenes/Apps/Messages/Message/Parts/MessageHeader.tsx
@@ -48,7 +48,7 @@ export default (props: Props) => {
   let application = companyApplications.find(a => a.id === message.application_id);
 
   const scrollToMessage = () => {
-    if (message.thread_id != message.id) {
+    if (message.thread_id !== message.id) {
       //TODO messageService.scrollTo({ id: message.thread_id });
     }
   };
@@ -85,6 +85,8 @@ export default (props: Props) => {
     }
   };
 
+  const icon = user?.status ? user.status.split(' ')[0] : undefined;
+  const status = user?.status ? user.status.split(' ')[1] : undefined;
   return (
     <div
       className={classNames('message-content-header-container', {
@@ -101,19 +103,17 @@ export default (props: Props) => {
             (!!user && User.getFullName(user)) ||
             (message.application_id && application?.identity?.name)}
         </span>
-        {!message.application_id && !!user && user.status_icon && user.status_icon[0] && (
+        {!message.application_id && !!user && (
           <div className="sender-status">
-            <Emojione size={12} type={user.status_icon[0]} /> {user.status_icon[1]}
+            {icon && <Emojione size={12} type={icon} />} {status && status}
           </div>
         )}
-
         {props.linkToThread && (
           <span className="reply-text">
             {Languages.t('scenes.apps.messages.input.replied_to')}
             <Link onClick={() => scrollToMessage()}>{parentMessage?.text}</Link>
           </span>
         )}
-
         {message.created_at && (
           <a
             className="date"

--- a/twake/frontend/src/app/scenes/Apps/Messages/Message/Parts/MessageHeader.tsx
+++ b/twake/frontend/src/app/scenes/Apps/Messages/Message/Parts/MessageHeader.tsx
@@ -86,7 +86,7 @@ export default (props: Props) => {
   };
 
   const icon = user?.status ? user.status.split(' ')[0] : undefined;
-  const status = user?.status ? user.status.split(' ')[1] : undefined;
+  const status = user?.status ? user.status.split(' ').splice(1).join(" ") : undefined;
   return (
     <div
       className={classNames('message-content-header-container', {
@@ -105,7 +105,7 @@ export default (props: Props) => {
         </span>
         {!message.application_id && !!user && (
           <div className="sender-status">
-            {icon && <Emojione size={12} type={icon} />} {status && status}
+            {!!icon && <Emojione size={12} type={icon} />} {!!status && status}
           </div>
         )}
         {props.linkToThread && (


### PR DESCRIPTION
![Capture d’écran de 2021-12-15 17-07-53](https://user-images.githubusercontent.com/36481167/146222747-0cf06ecb-ea54-4794-8f68-cda7fb6969c6.png)

You need to reload twake before seeing changes.

To be able to see the changes, we need to implement real time on the `useUser` hook after the #1815 pull request is merged