### PR TITLE
🌟 Improve search endpoint

### DIFF
--- a/twake/backend/node/src/cli/cmds/search_cmds/index_all.ts
+++ b/twake/backend/node/src/cli/cmds/search_cmds/index_all.ts
@@ -15,6 +15,10 @@ import { SearchServiceAPI } from "../../../core/platform/services/search/api";
 import CompanyUser, { TYPE as CompanyUserTYPE } from "../../../services/user/entities/company_user";
 import { Message, TYPE as MessageTYPE } from "../../../services/messages/entities/messages";
 import gr from "../../../services/global-resolver";
+import {
+  MessageFile,
+  TYPE as MessageFileTYPE,
+} from "../../../services/messages/entities/message-files";
 
 type Options = {
   repository?: string;
@@ -33,6 +37,10 @@ class SearchIndexAll {
   public async run(options: Options = {}): Promise<void> {
     const repositories: Map<string, Repository<any>> = new Map();
     repositories.set("messages", await this.database.getRepository(MessageTYPE, Message));
+    repositories.set(
+      "message_files",
+      await this.database.getRepository(MessageFileTYPE, MessageFile),
+    );
     repositories.set("users", await this.database.getRepository(UserTYPE, User));
     repositories.set("channels", await this.database.getRepository("channels", Channel));
     repositories.set(
@@ -42,7 +50,10 @@ class SearchIndexAll {
 
     const repository = repositories.get(options.repository);
     if (!repository) {
-      throw "No such repository ready for indexation, available are: users, applications";
+      throw (
+        "No such repository ready for indexation, available are: " +
+        Object.keys(repositories).join(", ")
+      );
     }
 
     // Complete user with companies in cache

--- a/twake/backend/node/src/core/platform/services/search/adapters/mongosearch/index.ts
+++ b/twake/backend/node/src/core/platform/services/search/adapters/mongosearch/index.ts
@@ -64,7 +64,7 @@ export default class MongoSearch extends SearchAdapter implements SearchAdapterI
       indexedPk[key] = 1;
     });
 
-    const indexedFields: any = entityDefinition.options.search.mongoMapping || {};
+    let indexedFields: any = entityDefinition.options.search.mongoMapping || {};
     if (!entityDefinition.options.search.mongoMapping) {
       Object.keys(columns).forEach(c => {
         const def = columns[c];
@@ -73,6 +73,8 @@ export default class MongoSearch extends SearchAdapter implements SearchAdapterI
         }
       });
     }
+
+    indexedFields = _.pick(indexedFields, ["text"]);
 
     logger.info(
       `${this.name} - Create indexes ${JSON.stringify(indexedFields)} for ${

--- a/twake/backend/node/src/core/platform/services/search/adapters/mongosearch/index.ts
+++ b/twake/backend/node/src/core/platform/services/search/adapters/mongosearch/index.ts
@@ -82,7 +82,7 @@ export default class MongoSearch extends SearchAdapter implements SearchAdapterI
 
     //Create one index for each type of indexes ["text"]
     Object.keys(indexedFields).forEach(k => {
-      collection.createIndex(indexedFields[k]);
+      collection.createIndex(indexedFields[k], { default_language: "none" });
     });
   }
 
@@ -195,6 +195,8 @@ export default class MongoSearch extends SearchAdapter implements SearchAdapterI
     const collection = this.mongodb.collection(`${searchPrefix}${index}`);
 
     const { query, sort, project } = buildSearchQuery<EntityType>(entityType, filters, options);
+
+    console.log(query);
 
     let cursor = collection.find({ ...query }).sort(sort);
     if (project) {

--- a/twake/backend/node/src/core/platform/services/search/adapters/mongosearch/search.ts
+++ b/twake/backend/node/src/core/platform/services/search/adapters/mongosearch/search.ts
@@ -22,10 +22,11 @@ export function buildSearchQuery<Entity>(
 
   //Build text searches
   if (options.$text) {
-    const mapping = entityDefinition?.options?.search?.mongoMapping?.text;
-    if (Object.values(mapping).includes("prefix")) {
-      query.$or = Object.keys(mapping).map(k => {
-        if (mapping[k] === "prefix") {
+    const prefixMapping = entityDefinition?.options?.search?.mongoMapping?.prefix || {};
+    const textMapping = entityDefinition?.options?.search?.mongoMapping?.text || {};
+    if (Object.values(prefixMapping).length > 0) {
+      query.$or = [...Object.keys(prefixMapping), ...Object.keys(textMapping)].map(k => {
+        if (prefixMapping[k] === "prefix") {
           return {
             [k]: new RegExp(`^${asciiFold(options.$text.$search || "")}`, "i"),
           };

--- a/twake/backend/node/src/core/platform/services/search/adapters/mongosearch/search.ts
+++ b/twake/backend/node/src/core/platform/services/search/adapters/mongosearch/search.ts
@@ -24,7 +24,8 @@ export function buildSearchQuery<Entity>(
   if (options.$text) {
     const prefixMapping = entityDefinition?.options?.search?.mongoMapping?.prefix || {};
     const textMapping = entityDefinition?.options?.search?.mongoMapping?.text || {};
-    if (Object.values(prefixMapping).length > 0) {
+    //Try to detect when we need prefix search
+    if (Object.values(prefixMapping).length > 0 && options.$text.$search.indexOf(" ") < 0) {
       query.$or = [...Object.keys(prefixMapping), ...Object.keys(textMapping)].map(k => {
         if (prefixMapping[k] === "prefix") {
           return {

--- a/twake/backend/node/src/services/applications/entities/application.search.ts
+++ b/twake/backend/node/src/services/applications/entities/application.search.ts
@@ -22,7 +22,7 @@ export default {
   esMapping: {
     properties: {
       company_id: { type: "keyword" },
-      name: { type: "text", index_prefixes: {} },
+      name: { type: "text", index_prefixes: { min_chars: 1 } },
       description: { type: "text" },
       categories: { type: "keyword" },
       compatibility: { type: "keyword" },

--- a/twake/backend/node/src/services/channels/entities/channel.search.ts
+++ b/twake/backend/node/src/services/channels/entities/channel.search.ts
@@ -16,7 +16,7 @@ export default {
   },
   esMapping: {
     properties: {
-      name: { type: "text", index_prefixes: {} },
+      name: { type: "text", index_prefixes: { min_chars: 1 } },
       workspace_id: { type: "keyword" },
       company_id: { type: "keyword" },
     },

--- a/twake/backend/node/src/services/channels/entities/channel.search.ts
+++ b/twake/backend/node/src/services/channels/entities/channel.search.ts
@@ -11,7 +11,7 @@ export default {
   },
   mongoMapping: {
     text: {
-      name: "text",
+      name: "prefix",
     },
   },
   esMapping: {

--- a/twake/backend/node/src/services/channels/entities/channel.search.ts
+++ b/twake/backend/node/src/services/channels/entities/channel.search.ts
@@ -11,6 +11,9 @@ export default {
   },
   mongoMapping: {
     text: {
+      name: "text",
+    },
+    prefix: {
       name: "prefix",
     },
   },

--- a/twake/backend/node/src/services/channels/entities/channel.search.ts
+++ b/twake/backend/node/src/services/channels/entities/channel.search.ts
@@ -13,9 +13,6 @@ export default {
     text: {
       name: "text",
     },
-    prefix: {
-      name: "prefix",
-    },
   },
   esMapping: {
     properties: {

--- a/twake/backend/node/src/services/channels/web/controllers/channel.ts
+++ b/twake/backend/node/src/services/channels/web/controllers/channel.ts
@@ -131,7 +131,7 @@ export class ChannelCrudController
     }>,
     reply: FastifyReply,
   ): Promise<ResourceListResponse<Channel>> {
-    if (request.query.q.length < 2) {
+    if (request.query.q.length < 1) {
       return { resources: [] };
     }
 

--- a/twake/backend/node/src/services/messages/api.ts
+++ b/twake/backend/node/src/services/messages/api.ts
@@ -23,6 +23,7 @@ import {
   MessageViewListOptions,
   MessageWithReplies,
   MessageWithRepliesWithUsers,
+  SearchMessageFilesOptions,
   SearchMessageOptions,
   ThreadExecutionContext,
 } from "./types";
@@ -31,6 +32,7 @@ import { ParticipantObject, Thread, ThreadPrimaryKey } from "./entities/threads"
 import { Message, MessagePrimaryKey, MessageWithUsers } from "./entities/messages";
 import { uuid } from "../../utils/types";
 import { PublicFile } from "../files/entities/file";
+import { MessageFile } from "./entities/message-files";
 
 export interface MessageUserBookmarksServiceAPI
   extends TwakeServiceProvider,
@@ -149,6 +151,12 @@ export interface MessageViewsServiceAPI extends TwakeServiceProvider, Initializa
     options: SearchMessageOptions,
     context?: ExecutionContext,
   ): Promise<ListResult<Message>>;
+
+  searchFiles(
+    pagination: Pagination,
+    options: SearchMessageFilesOptions,
+    context?: ExecutionContext,
+  ): Promise<ListResult<MessageFile>>;
 
   listUserMarkedFiles(
     userId: string,

--- a/twake/backend/node/src/services/messages/entities/message-files.search.ts
+++ b/twake/backend/node/src/services/messages/entities/message-files.search.ts
@@ -15,16 +15,16 @@ export default {
       is_file: !isMedia,
       created_at: entity.created_at,
 
-      company_id: entity.cache?.company_id,
-      workspace_id: entity.cache?.workspace_id,
-      channel_id: entity.cache?.channel_id,
-      user_id: entity.cache?.user_id,
+      cache_company_id: entity.cache?.company_id,
+      cache_workspace_id: entity.cache?.workspace_id,
+      cache_channel_id: entity.cache?.channel_id,
+      cache_user_id: entity.cache?.user_id,
     };
     return source;
   },
   mongoMapping: {
     text: {
-      name: "text",
+      name: "prefix",
     },
   },
   esMapping: {
@@ -37,10 +37,10 @@ export default {
       is_file: { type: "boolean" },
       created_at: { type: "number" },
 
-      company_id: { type: "keyword" },
-      workspace_id: { type: "keyword" },
-      channel_id: { type: "keyword" },
-      user_id: { type: "keyword" },
+      cache_company_id: { type: "keyword" },
+      cache_workspace_id: { type: "keyword" },
+      cache_channel_id: { type: "keyword" },
+      cache_user_id: { type: "keyword" },
     },
   },
 };

--- a/twake/backend/node/src/services/messages/entities/message-files.search.ts
+++ b/twake/backend/node/src/services/messages/entities/message-files.search.ts
@@ -1,0 +1,46 @@
+import { MessageFile } from "./message-files";
+
+export default {
+  index: "messages_files",
+  source: (entity: MessageFile) => {
+    const isMedia =
+      entity.metadata?.mime?.startsWith("video/") || entity.metadata?.mime?.startsWith("image/");
+
+    const source = {
+      name: entity.metadata?.name || "",
+      size: entity.metadata?.size || "",
+      source: entity.metadata?.source || "",
+      extension: (entity.metadata?.name || "").split(".").pop() || "",
+      is_media: isMedia,
+      is_file: !isMedia,
+      created_at: entity.created_at,
+
+      company_id: entity.cache?.company_id,
+      workspace_id: entity.cache?.workspace_id,
+      channel_id: entity.cache?.channel_id,
+      user_id: entity.cache?.user_id,
+    };
+    return source;
+  },
+  mongoMapping: {
+    text: {
+      name: "text",
+    },
+  },
+  esMapping: {
+    properties: {
+      name: { type: "text", index_prefixes: { min_chars: 1, max_chars: 20 } },
+      size: { type: "number" },
+      source: { type: "keyword" },
+      extension: { type: "keyword" },
+      is_media: { type: "boolean" },
+      is_file: { type: "boolean" },
+      created_at: { type: "number" },
+
+      company_id: { type: "keyword" },
+      workspace_id: { type: "keyword" },
+      channel_id: { type: "keyword" },
+      user_id: { type: "keyword" },
+    },
+  },
+};

--- a/twake/backend/node/src/services/messages/entities/message-files.search.ts
+++ b/twake/backend/node/src/services/messages/entities/message-files.search.ts
@@ -1,7 +1,7 @@
 import { MessageFile } from "./message-files";
 
 export default {
-  index: "messages_files",
+  index: "message_files",
   source: (entity: MessageFile) => {
     const isMedia =
       entity.metadata?.mime?.startsWith("video/") || entity.metadata?.mime?.startsWith("image/");

--- a/twake/backend/node/src/services/messages/entities/message-files.search.ts
+++ b/twake/backend/node/src/services/messages/entities/message-files.search.ts
@@ -24,6 +24,9 @@ export default {
   },
   mongoMapping: {
     text: {
+      name: "text",
+    },
+    prefix: {
       name: "prefix",
     },
   },

--- a/twake/backend/node/src/services/messages/entities/message-files.ts
+++ b/twake/backend/node/src/services/messages/entities/message-files.ts
@@ -2,11 +2,13 @@ import { Type } from "class-transformer";
 import { merge } from "lodash";
 import { Thumbnail } from "../../files/entities/file";
 import { Column, Entity } from "../../../core/platform/services/database/services/orm/decorators";
+import search from "./message-files.search";
 
 export const TYPE = "message_files";
 @Entity(TYPE, {
   primaryKey: [["message_id"], "id"],
   type: TYPE,
+  search,
 })
 export class MessageFile {
   @Type(() => String)
@@ -24,8 +26,19 @@ export class MessageFile {
   @Column("company_id", "timeuuid")
   company_id: string;
 
+  @Column("created_at", "number")
+  created_at: number;
+
   @Column("metadata", "encoded_json")
   metadata: MessageFileMetadata;
+
+  @Column("cache", "encoded_json")
+  cache: null | {
+    company_id: string;
+    workspace_id: string;
+    channel_id: string;
+    user_id: string;
+  };
 }
 
 export type MessageFileMetadata = {
@@ -40,7 +53,3 @@ export type MessageFileMetadata = {
 };
 
 export type MessageFilePrimaryKey = Pick<MessageFile, "message_id" | "id">;
-
-export function getInstance(file: MessageFile): MessageFile {
-  return merge(new MessageFile(), file);
-}

--- a/twake/backend/node/src/services/messages/entities/messages.ts
+++ b/twake/backend/node/src/services/messages/entities/messages.ts
@@ -60,7 +60,7 @@ export class Message {
   blocks: Block[];
 
   @Column("files", "encoded_json")
-  files: null | MessageFile[];
+  files: null | Partial<MessageFile>[];
 
   @Column("context", "encoded_json")
   context: any;

--- a/twake/backend/node/src/services/messages/services/messages.ts
+++ b/twake/backend/node/src/services/messages/services/messages.ts
@@ -704,6 +704,13 @@ export class ThreadMessagesService implements MessageThreadMessagesServiceAPI {
       entity.thread_id = message.thread_id;
       entity.id = file.id || undefined;
       entity.company_id = file.company_id;
+      entity.cache = {
+        company_id: message.cache?.company_id,
+        workspace_id: message.cache?.workspace_id,
+        channel_id: message.cache?.channel_id,
+        user_id: message.user_id,
+      };
+      entity.created_at = file.created_at;
 
       //If it is defined it should exists
       let messageFileExistOnDb = false;

--- a/twake/backend/node/src/services/messages/services/messages.ts
+++ b/twake/backend/node/src/services/messages/services/messages.ts
@@ -710,7 +710,7 @@ export class ThreadMessagesService implements MessageThreadMessagesServiceAPI {
         channel_id: message.cache?.channel_id,
         user_id: message.user_id,
       };
-      entity.created_at = file.created_at;
+      entity.created_at = file.created_at || new Date().getTime();
 
       //If it is defined it should exists
       let messageFileExistOnDb = false;

--- a/twake/backend/node/src/services/messages/services/views.ts
+++ b/twake/backend/node/src/services/messages/services/views.ts
@@ -297,11 +297,11 @@ export class ViewsServiceImpl implements MessageViewsServiceAPI {
         },
         {
           pagination,
-          ...(options.companyId ? { $in: [["company_id", [options.companyId]]] } : {}),
-          ...(options.workspaceId ? { $in: [["workspace_id", [options.workspaceId]]] } : {}),
-          ...(options.channelId ? { $in: [["channel_id", [options.channelId]]] } : {}),
+          ...(options.companyId ? { $in: [["cache_company_id", [options.companyId]]] } : {}),
+          ...(options.workspaceId ? { $in: [["cache_workspace_id", [options.workspaceId]]] } : {}),
+          ...(options.channelId ? { $in: [["cache_channel_id", [options.channelId]]] } : {}),
+          ...(options.sender ? { $in: [["cache_user_id", [options.sender]]] } : {}),
           ...(options.extension ? { $in: [["extension", [options.extension]]] } : {}),
-          ...(options.sender ? { $in: [["user_id", [options.sender]]] } : {}),
           $text: {
             $search: options.search,
           },

--- a/twake/backend/node/src/services/messages/types.ts
+++ b/twake/backend/node/src/services/messages/types.ts
@@ -136,6 +136,17 @@ export type SearchMessageOptions = {
   sender?: string;
 };
 
+export type SearchMessageFilesOptions = {
+  search?: string;
+  companyId?: string;
+  workspaceId?: string;
+  channelId?: string;
+  sender?: string;
+  isFile?: boolean;
+  isMedia?: boolean;
+  extension?: string;
+};
+
 export type InboxOptions = {
   companyId: string;
 };

--- a/twake/backend/node/src/services/messages/web/controllers/views.ts
+++ b/twake/backend/node/src/services/messages/web/controllers/views.ts
@@ -19,6 +19,8 @@ import { keyBy } from "lodash";
 import gr from "../../../global-resolver";
 import { CompanyExecutionContext } from "../../../applications/web/types";
 import { PublicFile } from "../../../files/entities/file";
+import { MessageFile } from "../../entities/message-files";
+import User from "src/services/user/entities/user";
 
 export class ViewsController {
   async feed(
@@ -175,7 +177,7 @@ export class ViewsController {
     }>,
     context: ChannelViewExecutionContext,
   ): Promise<ResourceListResponse<Message>> {
-    if (request.query.q.length < 2) {
+    if (request.query.q.length < 1) {
       return { resources: [] };
     }
 
@@ -240,6 +242,92 @@ export class ViewsController {
 
     return { resources: messages };
   }
+
+  async searchFiles(
+    request: FastifyRequest<{
+      Querystring: MessageViewSearchFilesQueryParameters;
+      Params: {
+        company_id: string;
+      };
+    }>,
+    context: ChannelViewExecutionContext,
+  ): Promise<ResourceListResponse<MessageFile>> {
+    if (request.query.q.length < 1) {
+      return { resources: [] };
+    }
+
+    const limit = +request.query.limit || 100;
+
+    async function* getNextMessageFiles(): AsyncIterableIterator<MessageFile> {
+      let lastPageToken = null;
+      let messageFiles: MessageFile[] = [];
+      let hasMoreMessageFiles = true;
+      do {
+        messageFiles = await gr.services.messages.views
+          .searchFiles(
+            new Pagination(lastPageToken, limit.toString()),
+            {
+              search: request.query.q,
+              companyId: request.params.company_id,
+              workspaceId: request.query.workspace_id,
+              channelId: request.query.channel_id,
+              ...(request.query.is_file ? { isFile: true } : {}),
+              ...(request.query.is_media ? { isMedia: true } : {}),
+              ...(request.query.sender ? { sender: request.query.sender } : {}),
+              ...(request.query.extension ? { extension: request.query.extension } : {}),
+            },
+            context,
+          )
+          .then((a: ListResult<MessageFile>) => {
+            lastPageToken = a.nextPage.page_token;
+            if (!lastPageToken) {
+              hasMoreMessageFiles = false;
+            }
+            return a.getEntities();
+          });
+
+        if (messageFiles.length) {
+          for (const messageFile of messageFiles) {
+            yield messageFile;
+          }
+        } else {
+          hasMoreMessageFiles = false;
+        }
+      } while (hasMoreMessageFiles);
+    }
+
+    const messageFiles = [] as (MessageFile & { message: Message; user: User })[];
+
+    for await (const msgFile of getNextMessageFiles()) {
+      const isChannelMember = await gr.services.channels.members.isChannelMember(
+        { id: request.currentUser.id },
+        {
+          company_id: msgFile.cache.company_id,
+          workspace_id: msgFile.cache.workspace_id,
+          id: msgFile.cache.channel_id,
+        },
+        50,
+      );
+      if (!isChannelMember) continue;
+
+      try {
+        const message = await gr.services.messages.messages.get({
+          thread_id: msgFile.thread_id,
+          id: msgFile.message_id,
+        });
+        const user = await gr.services.users.get({ id: msgFile.cache.user_id });
+
+        messageFiles.push({ ...msgFile, user, message });
+        if (messageFiles.length == limit) {
+          break;
+        }
+      } catch (e) {
+        continue;
+      }
+    }
+
+    return { resources: messageFiles };
+  }
 }
 
 export interface MessageViewListQueryParameters
@@ -256,6 +344,16 @@ export interface MessageViewSearchQueryParameters extends PaginationQueryParamet
   sender: string;
   has_files: boolean;
   has_medias: boolean;
+}
+
+export interface MessageViewSearchFilesQueryParameters extends PaginationQueryParameters {
+  q: string;
+  workspace_id: string;
+  channel_id: string;
+  sender: string;
+  is_file: boolean;
+  is_media: boolean;
+  extension: string;
 }
 
 function getChannelViewExecutionContext(

--- a/twake/backend/node/src/services/messages/web/controllers/views.ts
+++ b/twake/backend/node/src/services/messages/web/controllers/views.ts
@@ -20,7 +20,8 @@ import gr from "../../../global-resolver";
 import { CompanyExecutionContext } from "../../../applications/web/types";
 import { PublicFile } from "../../../files/entities/file";
 import { MessageFile } from "../../entities/message-files";
-import User from "../../../../services/user/entities/user";
+import { formatUser } from "../../../../utils/users";
+import { UserObject } from "../../../user/web/types";
 
 export class ViewsController {
   async feed(
@@ -296,7 +297,7 @@ export class ViewsController {
       } while (hasMoreMessageFiles);
     }
 
-    const messageFiles = [] as (MessageFile & { message: Message; user: User })[];
+    const messageFiles = [] as (MessageFile & { message: Message; user: UserObject })[];
 
     for await (const msgFile of getNextMessageFiles()) {
       const isChannelMember = await gr.services.channels.members.isChannelMember(
@@ -315,7 +316,7 @@ export class ViewsController {
           thread_id: msgFile.thread_id,
           id: msgFile.message_id,
         });
-        const user = await gr.services.users.get({ id: msgFile.cache.user_id });
+        const user = await formatUser(await gr.services.users.get({ id: msgFile.cache.user_id }));
 
         messageFiles.push({ ...msgFile, user, message });
         if (messageFiles.length == limit) {

--- a/twake/backend/node/src/services/messages/web/controllers/views.ts
+++ b/twake/backend/node/src/services/messages/web/controllers/views.ts
@@ -20,7 +20,7 @@ import gr from "../../../global-resolver";
 import { CompanyExecutionContext } from "../../../applications/web/types";
 import { PublicFile } from "../../../files/entities/file";
 import { MessageFile } from "../../entities/message-files";
-import User from "src/services/user/entities/user";
+import User from "../../../../services/user/entities/user";
 
 export class ViewsController {
   async feed(

--- a/twake/backend/node/src/services/messages/web/routes.ts
+++ b/twake/backend/node/src/services/messages/web/routes.ts
@@ -173,6 +173,13 @@ const routes: FastifyPluginCallback = (fastify: FastifyInstance, options, next) 
     handler: viewsController.search.bind(viewsController),
   });
 
+  fastify.route({
+    method: "GET",
+    url: "/companies/:company_id/files/search",
+    preValidation: [fastify.authenticate],
+    handler: viewsController.searchFiles.bind(viewsController),
+  });
+
   next();
 };
 

--- a/twake/backend/node/src/services/user/entities/user.search.ts
+++ b/twake/backend/node/src/services/user/entities/user.search.ts
@@ -20,6 +20,12 @@ export default {
   },
   mongoMapping: {
     text: {
+      first_name: "text",
+      last_name: "text",
+      email: "text",
+      username: "text",
+    },
+    prefix: {
       first_name: "prefix",
       last_name: "prefix",
       email: "prefix",

--- a/twake/backend/node/src/services/user/entities/user.search.ts
+++ b/twake/backend/node/src/services/user/entities/user.search.ts
@@ -38,10 +38,10 @@ export default {
   },
   esMapping: {
     properties: {
-      first_name: { type: "text", index_prefixes: {} },
-      last_name: { type: "text", index_prefixes: {} },
-      email: { type: "text", index_prefixes: {} },
-      username: { type: "text", index_prefixes: {} },
+      first_name: { type: "text", index_prefixes: { min_chars: 1 } },
+      last_name: { type: "text", index_prefixes: { min_chars: 1 } },
+      email: { type: "text", index_prefixes: { min_chars: 1 } },
+      username: { type: "text", index_prefixes: { min_chars: 1 } },
       companies: { type: "keyword" },
     },
   },

--- a/twake/backend/node/src/services/user/entities/user.search.ts
+++ b/twake/backend/node/src/services/user/entities/user.search.ts
@@ -9,15 +9,6 @@ export default {
       last_name: entity.last_name,
       email: entity.email_canonical,
       username: entity.username_canonical,
-      prefix: expandStringForPrefix(
-        entity.first_name +
-          " " +
-          entity.last_name +
-          " " +
-          (entity.email_canonical || "").split("@")[0] +
-          " " +
-          entity.username_canonical,
-      ),
     };
     if (entity.cache?.companies) {
       return {
@@ -29,11 +20,10 @@ export default {
   },
   mongoMapping: {
     text: {
-      first_name: "text",
-      last_name: "text",
-      email: "text",
-      username: "text",
-      prefix: "text",
+      first_name: "prefix",
+      last_name: "prefix",
+      email: "prefix",
+      username: "prefix",
     },
   },
   esMapping: {

--- a/twake/backend/node/test/e2e/channels/channels.search.spec.ts
+++ b/twake/backend/node/test/e2e/channels/channels.search.spec.ts
@@ -14,10 +14,6 @@ import {
   ChannelVisibility,
   WorkspaceExecutionContext,
 } from "../../../src/services/channels/types";
-import {
-  getPrivateRoomName,
-  getPublicRoomName,
-} from "../../../src/services/channels/services/channel/realtime";
 import { ChannelMember } from "../../../src/services/channels/entities";
 import { ChannelUtils, get as getChannelUtils } from "./utils";
 import { TestDbService } from "../utils.prepare.db";

--- a/twake/backend/node/test/e2e/channels/channels.search.spec.ts
+++ b/twake/backend/node/test/e2e/channels/channels.search.spec.ts
@@ -107,7 +107,7 @@ describe("The /internal/services/channels/v1 API", () => {
 
       for (let i = 0; i < 10; i++) {
         const channel = getChannel();
-        channel.name = `Test channel ${i}`;
+        channel.name = `test channel ${i}`;
         await gr.services.channels.channels.save(channel, {}, getContext());
 
         if (i == 0) continue;

--- a/twake/backend/node/test/e2e/messages/messages.files.search.spec.ts
+++ b/twake/backend/node/test/e2e/messages/messages.files.search.spec.ts
@@ -1,0 +1,124 @@
+import "reflect-metadata";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "@jest/globals";
+import { init, TestPlatform } from "../setup";
+import { ResourceUpdateResponse } from "../../../src/utils/types";
+import { deserialize } from "class-transformer";
+import { Thread } from "../../../src/services/messages/entities/threads";
+import { createMessage, e2e_createThread } from "./utils";
+import { MessageFile } from "../../../src/services/messages/entities/message-files";
+import { Message } from "../../../src/services/messages/entities/messages";
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import fs from "fs";
+import formAutoContent from "form-auto-content";
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import uuid, { v1 } from "node-uuid";
+
+describe("Search files", () => {
+  const filesUrl = "/internal/services/files/v1";
+  const messagesUrl = "/internal/services/messages/v1";
+  let platform: TestPlatform;
+
+  beforeAll(async () => {
+    platform = await init({
+      services: ["webserver", "database", "storage", "pubsub", "files", "previews"],
+    });
+    await platform.database.getConnector().drop();
+  });
+
+  afterAll(async done => {
+    await platform?.tearDown();
+    platform = null;
+    done();
+  });
+
+  const files = [
+    "../files/assets/sample.png",
+    "../files/assets/sample.gif",
+    "../files/assets/sample.pdf",
+    "../files/assets/sample.doc",
+    "../files/assets/sample.zip",
+  ].map(p => `${__dirname}/${p}`);
+
+  it("should return uploaded files", async done => {
+    const uploadedFiles = [];
+    for (const i in files) {
+      const file = files[i];
+
+      const form = formAutoContent({ file: fs.createReadStream(file) });
+      form.headers["authorization"] = `Bearer ${await platform.auth.getJWTToken()}`;
+
+      const uploadedFile = await platform.app.inject({
+        method: "POST",
+        url: `${filesUrl}/companies/${platform.workspace.company_id}/files?thumbnail_sync=1`,
+        ...form,
+      });
+
+      uploadedFiles.push(uploadedFile.json().resource);
+    }
+
+    let resources = await search("sample.png");
+    expect(resources.length).toEqual(1);
+
+    resources = await search("sample");
+    expect(resources.length).toEqual(5);
+
+    resources = await search("sam");
+    expect(resources.length).toEqual(5);
+
+    resources = await search("sample", { extension: "png" });
+    expect(resources.length).toEqual(5);
+
+    resources = await search("sample", { is_file: true });
+    expect(resources.length).toEqual(3);
+
+    resources = await search("sample", { is_media: true });
+    expect(resources.length).toEqual(2);
+
+    done();
+  });
+
+  async function search(
+    searchString: string,
+    options?: {
+      company_id?: string;
+      workspace_id?: string;
+      channel_id?: string;
+      limit?: number;
+      sender?: string;
+      is_file?: boolean;
+      is_media?: boolean;
+      extension?: string;
+    },
+  ): Promise<any[]> {
+    const jwtToken = await platform.auth.getJWTToken();
+
+    const query: any = options || {};
+
+    const response = await platform.app.inject({
+      method: "GET",
+      url: `${messagesUrl}/companies/${platform.workspace.company_id}/files/search`,
+      headers: {
+        authorization: `Bearer ${jwtToken}`,
+      },
+      query: {
+        ...query,
+        q: searchString,
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const json = response.json();
+    expect(json).toMatchObject({ resources: expect.any(Array) });
+    const resources = json.resources;
+    return resources;
+  }
+});
+
+function getContext(platform: TestPlatform) {
+  return {
+    company: { id: platform.workspace.company_id },
+    user: { id: platform.currentUser.id },
+  };
+}

--- a/twake/backend/node/test/e2e/messages/messages.files.search.spec.ts
+++ b/twake/backend/node/test/e2e/messages/messages.files.search.spec.ts
@@ -55,6 +55,27 @@ describe("Search files", () => {
         ...form,
       });
 
+      const resource = uploadedFile.json().resource;
+
+      const messageFile: Partial<MessageFile> = {
+        id: uuid.v1(),
+        company_id: platform.workspace.company_id,
+        metadata: {
+          source: "internal",
+          external_id: {
+            company_id: platform.workspace.company_id,
+            id: resource.id,
+          },
+          ...resource.metadata,
+        },
+      };
+
+      await e2e_createThread(
+        platform,
+        [],
+        createMessage({ text: "Some message", files: [messageFile] }),
+      );
+
       uploadedFiles.push(uploadedFile.json().resource);
     }
 

--- a/twake/backend/node/test/e2e/messages/messages.files.search.spec.ts
+++ b/twake/backend/node/test/e2e/messages/messages.files.search.spec.ts
@@ -100,19 +100,12 @@ describe("Search files", () => {
       uploadedFiles.push(uploadedFile.json().resource);
     }
 
-    //sleep 1s
     await new Promise(r => setTimeout(r, 2000));
 
     let resources = await search("sample");
-
-    //sleep 1s
-    await new Promise(r => setTimeout(r, 2000));
     expect(resources.length).toEqual(5);
 
     resources = await search("sample", { extension: "png" });
-
-    //sleep 1s
-    await new Promise(r => setTimeout(r, 2000));
     expect(resources.length).toEqual(1);
 
     resources = await search("sample", { is_file: true });

--- a/twake/backend/node/test/e2e/messages/messages.files.spec.ts
+++ b/twake/backend/node/test/e2e/messages/messages.files.spec.ts
@@ -15,7 +15,7 @@ import formAutoContent from "form-auto-content";
 // @ts-ignore
 import uuid, { v1 } from "node-uuid";
 
-describe("The Messages Threads feature", () => {
+describe("The Messages Files feature", () => {
   const url = "/internal/services/messages/v1";
   let platform: TestPlatform;
 

--- a/twake/backend/node/test/e2e/messages/messages.search.spec.ts
+++ b/twake/backend/node/test/e2e/messages/messages.search.spec.ts
@@ -85,7 +85,7 @@ describe("The /messages API", () => {
 
       const secondThreadId = await createThread("Another thread", [participant]);
       await createReply(secondThreadId, "First reply of second thread");
-      await createReply(secondThreadId, "Second reply of second thread a");
+      await createReply(secondThreadId, "Second reply of second thread is also a message");
 
       //Wait for indexation to happen
       await new Promise(r => setTimeout(r, 3000));
@@ -105,7 +105,17 @@ describe("The /messages API", () => {
       resources = await search("another");
       expect(resources.length).toEqual(1);
 
+      resources = await search("also");
+      expect(resources.length).toEqual(1);
+
+      resources = await search("of");
+      expect(resources.length).toEqual(4);
+
       resources = await search("a");
+
+      //sleep 1s
+      await new Promise(r => setTimeout(r, 2000));
+
       expect(resources.length).toEqual(1);
 
       done();

--- a/twake/backend/node/test/e2e/messages/messages.search.spec.ts
+++ b/twake/backend/node/test/e2e/messages/messages.search.spec.ts
@@ -85,7 +85,7 @@ describe("The /messages API", () => {
 
       const secondThreadId = await createThread("Another thread", [participant]);
       await createReply(secondThreadId, "First reply of second thread");
-      await createReply(secondThreadId, "Second reply of second thread");
+      await createReply(secondThreadId, "Second reply of second thread a");
 
       //Wait for indexation to happen
       await new Promise(r => setTimeout(r, 3000));
@@ -103,6 +103,9 @@ describe("The /messages API", () => {
       expect(resources.length).toEqual(3);
 
       resources = await search("another");
+      expect(resources.length).toEqual(1);
+
+      resources = await search("a");
       expect(resources.length).toEqual(1);
 
       done();

--- a/twake/backend/node/test/e2e/messages/utils.ts
+++ b/twake/backend/node/test/e2e/messages/utils.ts
@@ -1,3 +1,4 @@
+import { v1 } from "uuid";
 import {
   getInstance as getMessageInstance,
   Message,
@@ -21,7 +22,7 @@ export const e2e_createThread = async (
     },
     payload: {
       resource: {
-        participants: participants,
+        participants: participants || [],
       },
       options: {
         message: message,

--- a/twake/backend/node/test/e2e/run-all.js
+++ b/twake/backend/node/test/e2e/run-all.js
@@ -72,7 +72,7 @@ srcFiles = srcFiles.filter(p => p.indexOf(".spec.ts") >= 0 || p.indexOf(".test.t
 
   for (const path of localDevTests || srcFiles) {
     const testName = `test/e2e/${path.split("test/e2e/")[1]}`;
-    const args = `${testName} --forceExit --coverage --detectOpenHandles --runInBand --testTimeout=60000 --verbose=true`;
+    const args = `${testName} --forceExit --detectOpenHandles --runInBand --testTimeout=60000 --verbose=true`;
 
     try {
       //Show logs in the console if we are doing local dev tests

--- a/twake/backend/node/test/e2e/users/users.search.spec.ts
+++ b/twake/backend/node/test/e2e/users/users.search.spec.ts
@@ -101,6 +101,9 @@ describe("The /users API", () => {
       resources = await search("AleXis");
       expect(resources[0].email).toBe("alexis.goelans@twake.app");
 
+      resources = await search("alex");
+      expect(resources[0].email).toBe("alexis.goelans@twake.app");
+
       resources = await search("àlèXïs");
       expect(resources[0].email).toBe("alexis.goelans@twake.app");
 


### PR DESCRIPTION
#2221

- [x] Search with only one letter
- [x] Create searchable message_file entity
- [x] Create company/:id/search/files endpoint to search for files (with better options)
Doc is here: https://www.notion.so/linagora/Rest-APIs-232eb8e51c3743ccbb7aa3534a5a7db9
- [x] Add ability for mongo to do prefix search