### PR TITLE
🌟 Added support for image link preview and added a limit and timeout to links #2280 #2278

### DIFF
--- a/twake/backend/node/src/services/previews/services/links/processing/image.ts
+++ b/twake/backend/node/src/services/previews/services/links/processing/image.ts
@@ -1,0 +1,33 @@
+import { LinkPreview } from "../../../types";
+import { logger } from "../../../../../core/platform/framework";
+import imageProbe from "probe-image-size";
+import { getUrlFavicon, getDomain } from "../../../utils";
+
+/**
+ * Generate a preview for a given image url.
+ *
+ * @param {String} url - the input url
+ * @returns {Promise<LinkPreview>} - resolves when the preview is generated
+ */
+export const generateImageUrlPreview = async (url: string): Promise<LinkPreview | null> => {
+  try {
+    const favicon = (await getUrlFavicon(url)) || null;
+    const domain = getDomain(url);
+    const title = url.split("/").pop();
+    const { height: img_height, width: img_width } = await imageProbe(url);
+
+    return {
+      title,
+      domain,
+      favicon,
+      url,
+      img_height,
+      img_width,
+      description: null,
+      img: url,
+    };
+  } catch (error) {
+    logger.error(`failed to generate image url preview: ${error}`);
+    throw Error(`failed to generate image url preview: ${error}`);
+  }
+};

--- a/twake/backend/node/src/services/previews/services/links/processing/image.ts
+++ b/twake/backend/node/src/services/previews/services/links/processing/image.ts
@@ -11,7 +11,7 @@ import { getUrlFavicon, getDomain } from "../../../utils";
  */
 export const generateImageUrlPreview = async (url: string): Promise<LinkPreview | null> => {
   try {
-    const favicon = (await getUrlFavicon(url)) || null;
+    const favicon = (await getUrlFavicon(getWebsiteUrl(url))) || null;
     const domain = getDomain(url);
     const title = url.split("/").pop();
     const { height: img_height, width: img_width } = await imageProbe(url);
@@ -29,4 +29,9 @@ export const generateImageUrlPreview = async (url: string): Promise<LinkPreview 
   } catch (error) {
     logger.error(`failed to generate image url preview: ${error}`);
   }
+};
+
+const getWebsiteUrl = (url: string) => {
+  const urlObj = new URL(url);
+  return `${urlObj.protocol}//${urlObj.hostname}`;
 };

--- a/twake/backend/node/src/services/previews/services/links/processing/image.ts
+++ b/twake/backend/node/src/services/previews/services/links/processing/image.ts
@@ -28,6 +28,5 @@ export const generateImageUrlPreview = async (url: string): Promise<LinkPreview 
     };
   } catch (error) {
     logger.error(`failed to generate image url preview: ${error}`);
-    throw Error(`failed to generate image url preview: ${error}`);
   }
 };

--- a/twake/backend/node/src/services/previews/services/links/processing/link.ts
+++ b/twake/backend/node/src/services/previews/services/links/processing/link.ts
@@ -2,7 +2,7 @@ import { parser } from "html-metadata-parser";
 import { LinkPreview } from "../../../types";
 import { logger } from "../../../../../core/platform/framework";
 import imageProbe from "probe-image-size";
-import { getUrlFavicon, getDomain } from "../../../utils";
+import { getUrlFavicon, getDomain, TIMEOUT, MAX_SIZE } from "../../../utils";
 
 type HtmlImage = {
   src: string;
@@ -30,7 +30,10 @@ export async function generateLinkPreview(url: string): Promise<LinkPreview> {
  */
 const getUrlInformation = async (url: string): Promise<LinkPreview> => {
   try {
-    const parsedPage = await parser(url);
+    const parsedPage = await parser(url, {
+      timeout: TIMEOUT,
+      maxContentLength: MAX_SIZE,
+    });
     const title = parsedPage.og?.title || parsedPage.meta?.title || null;
     const description = parsedPage.og?.description || parsedPage.meta?.description || null;
     let img = parsedPage.og?.image || parsedPage.meta?.image || parsedPage.images?.[0] || null;

--- a/twake/backend/node/src/services/previews/services/links/processing/link.ts
+++ b/twake/backend/node/src/services/previews/services/links/processing/link.ts
@@ -1,8 +1,8 @@
 import { parser } from "html-metadata-parser";
-import getFavicons from "get-website-favicon";
 import { LinkPreview } from "../../../types";
 import { logger } from "../../../../../core/platform/framework";
 import imageProbe from "probe-image-size";
+import { getUrlFavicon, getDomain } from "../../../utils";
 
 type HtmlImage = {
   src: string;
@@ -12,36 +12,15 @@ type HtmlImage = {
  * Generate a thumbnail for a given url.
  *
  * @param {String[]} urls - the input urls
- * @returns {Promise<LinkPreview[]>} - resolves when the thumbnails are generated
+ * @returns {Promise<LinkPreview>} - resolves when the preview is generated
  */
-export async function generateLinksPreviews(urls: string[]): Promise<LinkPreview[]> {
-  const output: LinkPreview[] = [];
-
-  for (const url of urls) {
-    try {
-      output.push(await getUrlInformation(url));
-    } catch (error) {
-      logger.error(`failed to generate link preview: ${error}`);
-    }
-  }
-
-  return output;
-}
-
-/**
- * Get domain from a given url.
- *
- * @param {String} url - the input url
- * @returns {String} - resolves when the domain is retrieved
- */
-const getDomain = (url: string): string => {
+export async function generateLinkPreview(url: string): Promise<LinkPreview> {
   try {
-    const domain = new URL(url).hostname;
-    return domain.replace(/^www\./, "");
+    return await getUrlInformation(url);
   } catch (error) {
-    throw Error(`failed to get domain: ${error}`);
+    logger.error(`failed to generate link preview: ${error}`);
   }
-};
+}
 
 /**
  * get url information
@@ -82,24 +61,5 @@ const getUrlInformation = async (url: string): Promise<LinkPreview> => {
     };
   } catch (error) {
     throw Error(`failed to get url information: ${error}`);
-  }
-};
-
-/**
- * get url favicon
- *
- * @param {String} url - the input url
- * @returns {Promise<String | null >} - resolves when the favicon is retrieved
- */
-const getUrlFavicon = async (url: string): Promise<string | null> => {
-  try {
-    const result = await getFavicons(url);
-    if (!result.icons || !result.icons.length) {
-      return;
-    }
-
-    return result.icons[0].src;
-  } catch (error) {
-    logger.error(`failed to get url favicon: ${error}`);
   }
 };

--- a/twake/backend/node/src/services/previews/utils.ts
+++ b/twake/backend/node/src/services/previews/utils.ts
@@ -5,8 +5,8 @@ import getFavicons from "get-website-favicon";
 import { logger } from "../../core/platform/framework";
 import axios from "axios";
 
-const TIMEOUT = 5 * 1000;
-const MAX_SIZE = 5 * 1024 * 1024;
+export const TIMEOUT = 5 * 1000;
+export const MAX_SIZE = 5 * 1024 * 1024;
 
 const { unlink } = fsPromise;
 

--- a/twake/backend/node/src/services/previews/utils.ts
+++ b/twake/backend/node/src/services/previews/utils.ts
@@ -1,6 +1,12 @@
 import { v4 as uuidv4 } from "uuid";
 import mimes from "./services/files/processing/mime";
 import fs, { existsSync, promises as fsPromise } from "fs";
+import getFavicons from "get-website-favicon";
+import { logger } from "../../core/platform/framework";
+import axios from "axios";
+
+const TIMEOUT = 5 * 1000;
+const MAX_SIZE = 5 * 1024 * 1024;
 
 const { unlink } = fsPromise;
 
@@ -22,3 +28,56 @@ export async function cleanFiles(paths: string[]) {
     if (existsSync(path)) await unlink(path);
   }
 }
+
+/**
+ * get url favicon
+ *
+ * @param {String} url - the input url
+ * @returns {Promise<String | null >} - resolves when the favicon is retrieved
+ */
+export const getUrlFavicon = async (url: string): Promise<string | null> => {
+  try {
+    const result = await getFavicons(url);
+    if (!result.icons || !result.icons.length) {
+      return;
+    }
+
+    return result.icons[0].src;
+  } catch (error) {
+    logger.error(`failed to get url favicon: ${error}`);
+  }
+};
+
+/**
+ * Get domain from a given url.
+ *
+ * @param {String} url - the input url
+ * @returns {String} - resolves when the domain is retrieved
+ */
+export const getDomain = (url: string): string => {
+  try {
+    const domain = new URL(url).hostname;
+    return domain.replace(/^www\./, "");
+  } catch (error) {
+    throw Error(`failed to get domain: ${error}`);
+  }
+};
+
+/**
+ * Get url content type headers
+ *
+ * @param {string} url - the input url
+ * @returns {Promise<string | void>} - the request headers
+ */
+export const checkUrlContents = async (url: string): Promise<string | void> => {
+  try {
+    const response = await axios(url, {
+      maxContentLength: MAX_SIZE,
+      timeout: TIMEOUT,
+    });
+
+    return response.headers["content-type"];
+  } catch (error) {
+    throw Error(`failed to check url contents: ${error}`);
+  }
+};

--- a/twake/backend/node/test/unit/services/previews/services/links/processing/images.test.ts
+++ b/twake/backend/node/test/unit/services/previews/services/links/processing/images.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, jest, beforeEach, afterEach, afterAll } from "@jest/globals";
+import { generateImageUrlPreview } from "../../../../../../../src/services/previews/services/links/processing/image";
+
+import getFavicons from "get-website-favicon";
+import imageProbe from "probe-image-size";
+
+jest.mock("get-website-favicon");
+jest.mock("probe-image-size");
+
+beforeEach(() => {
+  (imageProbe as any).mockImplementation(() => ({
+    width: 320,
+    height: 240,
+  }));
+
+  (getFavicons as any).mockImplementation(() => ({
+    icons: [
+      {
+        src: "http://foo.bar/favicon.ico",
+      },
+    ],
+  }));
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+afterAll(() => {
+  jest.restoreAllMocks();
+});
+
+describe("the generateImageUrlPreview function", () => {
+  it("should return a promise", () => {
+    const result = generateImageUrlPreview("http://foo.bar");
+    expect(result).toBeInstanceOf(Promise);
+  });
+
+  it("should generate a preview for a given image url", async () => {
+    const result = await generateImageUrlPreview("https://foo.bar/image.jpg");
+    expect(result).toEqual({
+      title: "image.jpg", // title should be the file name
+      domain: "foo.bar",
+      favicon: "http://foo.bar/favicon.ico",
+      url: "https://foo.bar/image.jpg",
+      img_height: 320,
+      img_width: 240,
+      description: null,
+      img: "https://foo.bar/image.jpg",
+    });
+  });
+
+  // should return nothing in case of error
+  it("should return nothing in case of error", async () => {
+    (imageProbe as any).mockImplementation(() => {
+      throw new Error("failed to probe image");
+    });
+
+    const result = await generateImageUrlPreview("https://foo.bar/image.jpg");
+    expect(result).toBeUndefined();
+  });
+});

--- a/twake/backend/node/test/unit/services/previews/services/links/processing/images.test.ts
+++ b/twake/backend/node/test/unit/services/previews/services/links/processing/images.test.ts
@@ -43,14 +43,13 @@ describe("the generateImageUrlPreview function", () => {
       domain: "foo.bar",
       favicon: "http://foo.bar/favicon.ico",
       url: "https://foo.bar/image.jpg",
-      img_height: 320,
-      img_width: 240,
+      img_height: 240,
+      img_width: 320,
       description: null,
       img: "https://foo.bar/image.jpg",
     });
   });
 
-  // should return nothing in case of error
   it("should return nothing in case of error", async () => {
     (imageProbe as any).mockImplementation(() => {
       throw new Error("failed to probe image");

--- a/twake/backend/node/test/unit/services/previews/services/links/processing/service.test.ts
+++ b/twake/backend/node/test/unit/services/previews/services/links/processing/service.test.ts
@@ -1,0 +1,109 @@
+import {
+  describe,
+  expect,
+  it,
+  jest,
+  beforeEach,
+  afterEach,
+  afterAll,
+  beforeAll,
+} from "@jest/globals";
+import { LinkPreviewProcessService } from "../../../../../../../src/services/previews/services/links/processing/service";
+import { generateLinkPreview } from "../../../../../../../src/services/previews/services/links/processing/link";
+import { generateImageUrlPreview } from "../../../../../../../src/services/previews/services/links/processing/image";
+import axios from "axios";
+
+jest.mock("axios");
+jest.mock("../../../../../../../src/services/previews/services/links/processing/link");
+jest.mock("../../../../../../../src/services/previews/services/links/processing/image");
+
+let service: LinkPreviewProcessService;
+
+beforeEach(async () => {
+  (axios as any).mockImplementation(() => ({
+    headers: {
+      "content-type": "text/html",
+    },
+  }));
+
+  (generateLinkPreview as any).mockImplementation(() => ({
+    title: "Foo",
+    description: "Bar",
+    img: "http://foo.bar/image.jpg",
+    favicon: "http://foo.bar/favicon.ico",
+  }));
+
+  (generateImageUrlPreview as any).mockImplementation(() => ({
+    title: "image.jpg",
+    description: null,
+    img: "http://foo.bar/image.jpg",
+    favicon: "http://foo.bar/favicon.ico",
+  }));
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+afterAll(() => {
+  jest.restoreAllMocks();
+});
+
+beforeAll(async () => {
+  service = await new LinkPreviewProcessService().init();
+});
+
+describe("the LinkPreviewProcessService service", () => {
+  it("should return a promise", () => {
+    const result = service.generatePreviews(["http://foo.bar"]);
+    expect(result).toBeInstanceOf(Promise);
+  });
+
+  it("should call generateLinkPreview when it's a html page", async () => {
+    (axios as any).mockImplementation(() => ({
+      headers: {
+        "content-type": "text/html",
+      },
+    }));
+
+    await service.generatePreviews(["http://foo.bar"]);
+    expect(generateLinkPreview).toHaveBeenCalled();
+  });
+
+  it("should call generateImageUrlPreview when it's an image", async () => {
+    (axios as any).mockImplementation(() => ({
+      headers: {
+        "content-type": "image/jpeg",
+      },
+    }));
+
+    await service.generatePreviews(["http://foo.bar/image.jpg"]);
+    expect(generateImageUrlPreview).toHaveBeenCalled();
+  });
+
+  it("should skip if the url content is not supported", async () => {
+    (axios as any).mockImplementation(() => ({
+      headers: {
+        "content-type": "application/json",
+      },
+    }));
+
+    await service.generatePreviews(["http://foo.bar"]);
+    expect(generateLinkPreview).not.toHaveBeenCalled();
+    expect(generateImageUrlPreview).not.toHaveBeenCalled();
+  });
+
+  // should filter null values
+  it("should filter null values", async () => {
+    (axios as any).mockImplementation(() => ({
+      headers: {
+        "content-type": "text/html",
+      },
+    }));
+
+    (generateLinkPreview as any).mockImplementation(() => null);
+
+    const result = await service.generatePreviews(["http://foo.bar", "http://foo.xyz"]);
+    expect(result).toEqual([]);
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Added support for image link preview
- checks the size of the content to preview and sets a maximum of 5 MB per link
- adds a 5 seconds timeout when generating previews 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/linagora/Twake/issues/2280
https://github.com/linagora/Twake/issues/2278

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- missing support for image link previews
- URLs to preview are not checked and could cause a problem for big files

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally

## Screenshots (if appropriate):

https://user-images.githubusercontent.com/6764881/173596737-a4d3f0d0-338b-4d86-966c-56e0924189dc.mp4

![image](https://user-images.githubusercontent.com/6764881/173596720-284d60f2-3f53-4f9f-ae83-8a6dbdab46eb.png)

![image](https://user-images.githubusercontent.com/6764881/173597351-49f4768e-64af-48f4-b454-5b42ef65e53d.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added the Signed-off-by statement at the end of my commit message.
