### PR TITLE
🛠 Fixed message link previews being removable by everyone

### DIFF
--- a/twake/backend/node/src/services/messages/services/messages-operations.ts
+++ b/twake/backend/node/src/services/messages/services/messages-operations.ts
@@ -184,6 +184,11 @@ export class ThreadMessagesOperationsService {
       throw Error("Can't edit message links previews.");
     }
 
+    if (context.user.id !== message.user_id) {
+      logger.error("You can't remove link preview from another user message.");
+      throw Error("Can't edit message links previews.");
+    }
+
     const decoded_url = decodeURIComponent(operation.encoded_link);
 
     message.links = message.links.filter(({ url }: { url: string }) => url !== decoded_url);

--- a/twake/frontend/src/app/views/applications/messages/message/parts/LinkPreview.tsx
+++ b/twake/frontend/src/app/views/applications/messages/message/parts/LinkPreview.tsx
@@ -2,6 +2,7 @@ import React, { useContext } from 'react';
 import { MessageLinkType } from 'app/features/messages/types/message';
 import './LinkPreview.scss';
 import { useMessage } from 'app/features/messages/hooks/use-message';
+import User from 'app/features/users/services/current-user-service';
 import { MessageContext } from '../message-with-replies';
 import { X } from 'react-feather';
 import { Col, Row } from 'antd';
@@ -12,15 +13,17 @@ type PropsType = {
 
 export default ({ preview }: PropsType): React.ReactElement => {
   const context = useContext(MessageContext);
-  const { deleteLinkPreview } = useMessage(context);
+  const { deleteLinkPreview, message } = useMessage(context);
 
   return (
     <Row>
       <Col>
         <div className="ant-card ant-card-bordered ant-card-small ant-card-type-inner link-preview">
-          <div className="delete-link-preview">
-            <X size={16} onClick={() => deleteLinkPreview(preview.url)} />
-          </div>
+          {message.user_id === User.getCurrentUserId() ? (
+            <div className="delete-link-preview">
+              <X size={16} onClick={() => deleteLinkPreview(preview.url)} />
+            </div>
+           ) : null}
           <div className="ant-card-body">
             <div className="ant-card-meta">
               <div className="ant-card-meta-detail">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- adds frontend and backend checks to only allow the message author to delete a link preview

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/linagora/Twake/issues/2298

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- fixes a bug

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
