### PR TITLE
🛠 Fix console invitation typo

### DIFF
--- a/twake/backend/node/src/services/console/clients/remote.ts
+++ b/twake/backend/node/src/services/console/clients/remote.ts
@@ -87,7 +87,7 @@ export class ConsoleRemoteClient implements ConsoleServiceClient {
 
       const result = await this.client
         .post(
-          `/api/companies/${company.code}/${isNewConsole ? "invitation" : "users/invitation"}`,
+          `/api/companies/${company.code}/${isNewConsole ? "invitations" : "users/invitation"}`,
           invitationData,
           {
             auth: this.auth(),


### PR DESCRIPTION
- Missing a s in api url