### PR TITLE
🛠 Changed delete link preview to use POST instead of DELETE

### DIFF
--- a/twake/backend/node/src/services/messages/api.ts
+++ b/twake/backend/node/src/services/messages/api.ts
@@ -125,7 +125,7 @@ export interface MessageThreadMessagesServiceAPI
     item: {
       message_id: string;
       thread_id: string;
-      encoded_link: string;
+      link: string;
     },
     context: ThreadExecutionContext,
   ): Promise<SaveResult<Message>>;

--- a/twake/backend/node/src/services/messages/services/messages-operations.ts
+++ b/twake/backend/node/src/services/messages/services/messages-operations.ts
@@ -189,9 +189,7 @@ export class ThreadMessagesOperationsService {
       throw Error("Can't edit message links previews.");
     }
 
-    const decoded_url = decodeURIComponent(operation.encoded_link);
-
-    message.links = message.links.filter(({ url }: { url: string }) => url !== decoded_url);
+    message.links = message.links.filter(({ url }: { url: string }) => url !== operation.link);
 
     await this.repository.save(message);
     this.threadMessagesService.onSaved(message, { created: false }, context);

--- a/twake/backend/node/src/services/messages/types.ts
+++ b/twake/backend/node/src/services/messages/types.ts
@@ -164,5 +164,5 @@ export type FlatPinnedFromMessage = {
 export interface DeleteLinkOperation {
   message_id: string;
   thread_id: string;
-  encoded_link: string;
+  link: string;
 }

--- a/twake/backend/node/src/services/messages/web/controllers/messages.ts
+++ b/twake/backend/node/src/services/messages/web/controllers/messages.ts
@@ -362,6 +362,9 @@ export class MessagesController
         message_id: string;
         encoded_url: string;
       };
+      Body: {
+        url: string;
+      };
     }>,
     reply: FastifyReply,
   ): Promise<ResourceUpdateResponse<Message>> {
@@ -371,7 +374,7 @@ export class MessagesController
         {
           message_id: request.params.message_id,
           thread_id: request.params.thread_id,
-          encoded_link: request.params.encoded_url,
+          link: request.body.url,
         },
         context,
       );

--- a/twake/backend/node/src/services/messages/web/routes.ts
+++ b/twake/backend/node/src/services/messages/web/routes.ts
@@ -135,8 +135,8 @@ const routes: FastifyPluginCallback = (fastify: FastifyInstance, options, next) 
   });
 
   fastify.route({
-    method: "DELETE",
-    url: "/companies/:company_id/threads/:thread_id/messages/:message_id/links/:encoded_url",
+    method: "POST",
+    url: "/companies/:company_id/threads/:thread_id/messages/:message_id/deletelink",
     preValidation: [fastify.authenticate],
     handler: messagesController.deleteLinkPreview.bind(messagesController),
   });

--- a/twake/frontend/src/app/features/messages/api/message-api-client.ts
+++ b/twake/frontend/src/app/features/messages/api/message-api-client.ts
@@ -150,9 +150,9 @@ class MessageAPIClient {
    * @returns {Promise<void>}
    */
   async deleteLinkPreview(companyId: string, threadId: string, messageId: string, url: string) {
-    const encoded_link = encodeURIComponent(url);
-    const response = await Api.delete<{ resource: NodeMessage }>(
-      `${this.prefixUrl}/companies/${companyId}/threads/${threadId}/messages/${messageId}/links/${encoded_link}`,
+    const response = await Api.post<{ url: string }, { resource: NodeMessage }>(
+      `${this.prefixUrl}/companies/${companyId}/threads/${threadId}/messages/${messageId}/deletelink`,
+      { url },
     );
 
     return response.resource;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- changed the backend endpoint to use POST
- changed the frontend client to use POST

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#2300 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- some URL previews could not be removed due to their links or the URL itself

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/6764881/174056412-ec792479-2ea1-4b30-b3d8-ecc1afaca68f.png)
![image](https://user-images.githubusercontent.com/6764881/174056475-060dc8a4-9946-42db-8454-356b38b78d10.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
