### PR TITLE
🛠  Fixed title and description mixing up in link preview

### DIFF
--- a/twake/frontend/src/app/views/applications/messages/message/parts/LinkPreview.tsx
+++ b/twake/frontend/src/app/views/applications/messages/message/parts/LinkPreview.tsx
@@ -37,7 +37,7 @@ export default ({ preview }: PropsType): React.ReactElement => {
                 href={preview.url}
                 target="_blank"
                 rel="noreferrer"
-                className="truncate text-ellipsis	max-w-full"
+                className="truncate text-ellipsis	w-full"
               >
                 {preview.title}
               </a>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- UI fix: title now takes the entire space to prevent being mixed up with the description

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#2387 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- UI fix

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/6764881/177130639-42df2f68-b283-4cab-8e62-771a9285ee54.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
