### PR TITLE
🛠  skip message link previews if there is nothing to preview

### DIFF
--- a/twake/backend/node/src/services/previews/services/links/processing/link.ts
+++ b/twake/backend/node/src/services/previews/services/links/processing/link.ts
@@ -41,6 +41,11 @@ const getUrlInformation = async (url: string): Promise<LinkPreview> => {
     const title = parsedPage.og?.title || parsedPage.meta?.title || null;
     const description = parsedPage.og?.description || parsedPage.meta?.description || null;
     let img = parsedPage.og?.image || parsedPage.meta?.image || parsedPage.images?.[0] || null;
+
+    if (!title && !description && !img) {
+      throw new Error("not enough information to generate link preview");
+    }
+
     const favicon = (await getUrlFavicon(url)) || null;
     const domain = getDomain(url);
     let img_height: number | null = null,

--- a/twake/backend/node/src/services/previews/services/links/processing/service.ts
+++ b/twake/backend/node/src/services/previews/services/links/processing/service.ts
@@ -41,6 +41,8 @@ export class LinkPreviewProcessService implements LinkPreviewServiceAPI {
       }
     }
 
-    return result.filter(Boolean);
+    return result.filter(
+      preview => preview && (preview.title || preview.description || preview.img),
+    );
   }
 }

--- a/twake/frontend/src/app/views/applications/messages/message/parts/MessageContent.tsx
+++ b/twake/frontend/src/app/views/applications/messages/message/parts/MessageContent.tsx
@@ -135,7 +135,9 @@ export default (props: Props) => {
               {message?.files && (message?.files?.length || 0) > 0 && <MessageAttachments />}
               {message?.links &&
                 (message?.links?.length || 0) > 0 &&
-                message.links.map((preview, i) => <LinkPreview key={i} preview={preview} />)}
+                message.links
+                  .filter(link => link && (link.title || link.description || link.img))
+                  .map((preview, i) => <LinkPreview key={i} preview={preview} />)}
               {!messageSaveFailed && <Reactions />}
               {messageSaveFailed && !messageIsLoading && <RetryButtons />}
             </>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- backend: skip previews that don't have enough information to preview ( at least should have a title or description or image )
- backend: skip the rest of the generation process if no title and no image and no description are found ( gains time cause no favicon fetching and so on ).
- frontend: filter out invalid previews  

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- #2397 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- some links have previews with just the domain, basically an empty preview.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/6764881/177832734-2dd7bb3a-2c0d-40b9-955e-1c3284ba086a.png)
![image](https://user-images.githubusercontent.com/6764881/177832958-10595949-2e2a-4dfa-8137-d47d31adf5af.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
