### PR TITLE
🛠  Fixed channel medias and files view having results from previous channels

### DIFF
--- a/twake/frontend/src/app/components/channel-attachement-list/parts/channel-attachment.tsx
+++ b/twake/frontend/src/app/components/channel-attachement-list/parts/channel-attachment.tsx
@@ -8,7 +8,6 @@ import {
 import { channelAttachmentListState } from 'app/features/channels/state/channel-attachment-list';
 import fileUploadApiClient from 'app/features/files/api/file-upload-api-client';
 import { Message, MessageFileType } from 'app/features/messages/types/message';
-import useRouterWorkspace from 'app/features/router/hooks/use-router-workspace';
 import { UserType } from 'app/features/users/types/user';
 import Media from 'app/molecules/media';
 import React from 'react';
@@ -46,7 +45,6 @@ export default ({ file, is_media }: PropsType): React.ReactElement => {
 
 const ChannelFile = ({ file }: FilePreviewType): React.ReactElement => {
   const [, setOpen] = useRecoilState(channelAttachmentListState);
-  const workspaceId = useRouterWorkspace();
   const name = file?.metadata?.name;
   const extension = name?.split('.').pop();
   const previewUrl = fileUploadApiClient.getFileThumbnailUrlFromMessageFile(file);

--- a/twake/frontend/src/app/features/channels/hooks/use-channel-media-files.ts
+++ b/twake/frontend/src/app/features/channels/hooks/use-channel-media-files.ts
@@ -20,6 +20,9 @@ export const useChannelAttachmentList = (type: 'file' | 'media') => {
     LoadingState(`useChannelAttachmentList-${type}-${companyId}-${workspaceId}-${channelId}`),
   );
   const [isOpen] = useRecoilState(channelAttachmentListState);
+  const [, setchannelFiles] = useRecoilState(channelAttachmentFileState(companyId));
+  const [, setchannelMedia] = useRecoilState(channelAttachmentMediaState(companyId));
+
   const [result, setResult] = useRecoilState(
     type === 'media'
       ? channelAttachmentMediaState(companyId)
@@ -70,6 +73,16 @@ export const useChannelAttachmentList = (type: 'file' | 'media') => {
     }
   }
 
+  const reset = () => {
+    const update = {
+      results: [],
+      nextPage: null,
+    }
+
+    setchannelFiles(update);
+    setchannelMedia(update);
+  }
+
   useGlobalEffect(
     `useChannelAttachmentList${type}`,
     () => {
@@ -78,6 +91,8 @@ export const useChannelAttachmentList = (type: 'file' | 'media') => {
           setLoading(true);
           await loadItems();
         })();
+      } else {
+        reset();
       }
     },
     [channelId, workspaceId, isOpen],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Fixes having files and medias from previous channels
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#2429 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- fixes a bug where users can see media that doesn't belong to the current channel.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
