### PR TITLE
🛠️ quoted reply improvements

### DIFF
--- a/twake/frontend/public/locales/en.json
+++ b/twake/frontend/public/locales/en.json
@@ -930,5 +930,6 @@
     "components.channel_attachement_list.title": "Channel files and medias",
     "components.channel_attachement_list.open": "Open gallery",
     "components.channel_attachement_list.nothing_found": "Nothing here yet",
-    "molecules.message_quote.deleted": "This message was deleted"
+    "molecules.message_quote.deleted": "This message was deleted",
+    "molecules.quoted_content.attachement": "Attachment"
 }

--- a/twake/frontend/src/app/components/quoted-message/quoted-message.tsx
+++ b/twake/frontend/src/app/components/quoted-message/quoted-message.tsx
@@ -8,6 +8,7 @@ import useRouterChannel from 'app/features/router/hooks/use-router-channel';
 import User from 'app/features/users/services/current-user-service';
 import { gotoMessage } from 'src/utils/messages';
 import useRouterWorkspace from 'app/features/router/hooks/use-router-workspace';
+import QuotedContent from 'app/molecules/quoted-content';
 
 type PropsType = {
   closable?: boolean;
@@ -33,10 +34,11 @@ export default ({ closable = true, onClose }: PropsType): React.ReactElement => 
   const author = useUser(message.user_id);
   const authorName = author ? User.getFullName(author) : 'Anonymous';
   const deleted = message.subtype === 'deleted';
+  const quotedContent = <QuotedContent message={message} />
 
   return (
     <MessageQuote
-      message={message.text}
+      message={quotedContent}
       author={authorName}
       closable={closable}
       onClose={onClose}

--- a/twake/frontend/src/app/features/messages/hooks/use-message-editor.ts
+++ b/twake/frontend/src/app/features/messages/hooks/use-message-editor.ts
@@ -36,7 +36,7 @@ export const useMessageEditor = (key: EditorKey) => {
     : `new-${key.channelId}`;
   const [editor, setEditor] = useRecoilState(MessagesEditorState(location));
   const editorRef = useRef(editor);
-  const { isActive: isQuoted, message: quotedMessageId } = useMessageQuoteReply(key.channelId || '');
+  const { isActive: isQuoted, message: quotedMessageId, close: closeQuoteReply } = useMessageQuoteReply(key.channelId || '');
   let quotedMessage: MessageWithReplies | null = null;
   let message: NodeMessage | null = null;
   if (key.messageId) {
@@ -77,6 +77,7 @@ export const useMessageEditor = (key: EditorKey) => {
 
     if (isQuoted && quotedMessage) {
       editedMessage.quote_message = quotedMessage;
+      closeQuoteReply();
     }
 
     const tempMessage = {

--- a/twake/frontend/src/app/molecules/message-quote/index.tsx
+++ b/twake/frontend/src/app/molecules/message-quote/index.tsx
@@ -4,7 +4,7 @@ import Languages from 'app/features/global/services/languages-service';
 import { X } from 'react-feather';
 
 type PropsType = {
-  message: string;
+  message: JSX.Element;
   author: string;
   closable?: boolean;
   deleted?: boolean;
@@ -34,7 +34,7 @@ export default ({
           {deleted ? (
             <Info className="italic">{Languages.t('molecules.message_quote.deleted')}</Info>
           ) : (
-            <Base>{message}</Base>
+            message
           )}
         </div>
       </div>

--- a/twake/frontend/src/app/molecules/quoted-content/index.tsx
+++ b/twake/frontend/src/app/molecules/quoted-content/index.tsx
@@ -1,0 +1,23 @@
+import { Base } from 'app/atoms/text';
+import Languages from 'app/features/global/services/languages-service';
+import { MessageWithReplies } from 'app/features/messages/types/message';
+import PossiblyPendingAttachment from 'app/views/applications/messages/message/parts/PossiblyPendingAttachment';
+import React from 'react';
+import { Image } from 'react-feather';
+
+type PropsType = {
+  message: MessageWithReplies;
+};
+
+export default ({ message }: PropsType): React.ReactElement => {
+  return message.text && message.text.length ? (
+    <Base>{message.text}</Base>
+  ) : message.files?.[0] ? (
+    <PossiblyPendingAttachment file={message.files?.[0]} type="message" />
+  ) : (
+    <div className="flex flex-row space-x-2">
+      <Image size={20} />
+      <Base>{Languages.t('molecules.quoted_content.attachement')}</Base>
+    </div>
+  );
+};

--- a/twake/frontend/src/app/views/applications/messages/message/parts/MessageContent.tsx
+++ b/twake/frontend/src/app/views/applications/messages/message/parts/MessageContent.tsx
@@ -26,6 +26,7 @@ import { useUser } from 'app/features/users/hooks/use-user';
 import User from 'app/features/users/services/current-user-service';
 import { gotoMessage } from 'src/utils/messages';
 import useRouterWorkspace from 'app/features/router/hooks/use-router-workspace';
+import QuotedContent from 'app/molecules/quoted-content';
 
 type Props = {
   linkToThread?: boolean;
@@ -101,6 +102,7 @@ export default (props: Props) => {
   const messageSaveFailed = (message as any)._status === 'failed';
 
   const isChannelMember = useIsChannelMember(channelId);
+  const quotedContent = <QuotedContent message={quotedMessage} />;
 
   return (
     <div
@@ -118,7 +120,7 @@ export default (props: Props) => {
       {showQuotedMessage && (
         <MessageQuote
           author={authorName}
-          message={quotedMessage.text}
+          message={quotedContent}
           closable={false}
           deleted={deletedQuotedMessage}
           goToMessage={() =>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- adds the ability to quote reply attachments.
- closes the quote message indicator after sending the message. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#2456 
#2460

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- solves messages with only attached files appearing empty when quoted.
- fixes quote reply indicator not disappearing when sending messages.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/6764881/187088596-58aa25d1-4e74-4b0c-aff2-36e2d8366d57.png)

https://user-images.githubusercontent.com/6764881/187158656-76fc519b-e455-49f2-b03b-bbd922a34992.mp4


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)