### PR TITLE
🛠  fixed backend binding the default frontend port

### DIFF
--- a/twake/docker-compose.dev.mongo.yml
+++ b/twake/docker-compose.dev.mongo.yml
@@ -11,7 +11,7 @@ services:
   node:
     image: twaketech/twake-node
     ports:
-      - 3000:3000
+      - 4000:3000
       - 8000:3000
       - 9229:9229
     environment:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- changed the exposed backend port to 4000

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- the MongoDB dev backend port is exposed to port 3000 which is the default port for the `craco start` leading  to errors and confusion when you run the frontend first and vice versa.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally
