### PR TITLE
🛠  fixed channel medias and files not getting updated when new files are sent

### DIFF
--- a/twake/frontend/src/app/components/channel-attachement-list/parts/channel-files.tsx
+++ b/twake/frontend/src/app/components/channel-attachement-list/parts/channel-files.tsx
@@ -1,5 +1,5 @@
 import { useChannelFileList } from 'app/features/channels/hooks/use-channel-media-files';
-import React from 'react';
+import React, { useEffect } from 'react';
 import ChannelAttachment from './channel-attachment';
 import { LoadingAttachements, NoAttachements } from './commun';
 import PerfectScrollbar from 'react-perfect-scrollbar';
@@ -9,7 +9,11 @@ type PropsType = {
 };
 
 export default ({ maxItems }: PropsType): React.ReactElement => {
-  const { loading, result, loadMore } = useChannelFileList();
+  const { loading, result, loadMore, loadItems } = useChannelFileList();
+
+  useEffect(() => {
+    loadItems();
+  }, []);
 
   return (
     <PerfectScrollbar

--- a/twake/frontend/src/app/components/channel-attachement-list/parts/channel-medias.tsx
+++ b/twake/frontend/src/app/components/channel-attachement-list/parts/channel-medias.tsx
@@ -1,6 +1,6 @@
 import { useChannelMediaList } from 'app/features/channels/hooks/use-channel-media-files';
 import fileUploadApiClient from 'app/features/files/api/file-upload-api-client';
-import React from 'react';
+import React, { useEffect } from 'react';
 import ChannelAttachment from './channel-attachment';
 import { LoadingAttachements, NoAttachements } from './commun';
 import PerfectScrollbar from 'react-perfect-scrollbar';
@@ -10,7 +10,11 @@ type PropsType = {
 };
 
 export default ({ maxItems }: PropsType): React.ReactElement => {
-  const { loading, result, loadMore } = useChannelMediaList();
+  const { loading, result, loadMore, loadItems } = useChannelMediaList();
+
+  useEffect(() => {
+    loadItems();
+  }, []);
 
   return (
     <>

--- a/twake/frontend/src/app/features/channels/hooks/use-channel-media-files.ts
+++ b/twake/frontend/src/app/features/channels/hooks/use-channel-media-files.ts
@@ -13,6 +13,7 @@ import {
 import _ from 'lodash';
 
 export const useChannelAttachmentList = (type: 'file' | 'media') => {
+  const limit = 25;
   const companyId = useRouterCompany();
   const workspaceId = useRouterWorkspace();
   const channelId = useRouterChannel();
@@ -31,7 +32,7 @@ export const useChannelAttachmentList = (type: 'file' | 'media') => {
 
   const options = _.omitBy(
     {
-      limit: 25,
+      limit,
       is_file: type === 'file' || undefined,
       is_media: type === 'media' || undefined,
       workspace_id: workspaceId,
@@ -58,7 +59,7 @@ export const useChannelAttachmentList = (type: 'file' | 'media') => {
   };
 
   const loadMore = async () => {
-    if (result.nextPage) {
+    if (result.nextPage && result.results.length % limit === 0) {
       const response = await messageApiClient.searchFile(null, { ...options, next_page_token: result.nextPage });
       const results = (response.resources || []).sort(
         (a, b) => (b?.message?.created_at || 0) - (a?.message?.created_at || 0),
@@ -86,12 +87,7 @@ export const useChannelAttachmentList = (type: 'file' | 'media') => {
   useGlobalEffect(
     `useChannelAttachmentList${type}`,
     () => {
-      if (isOpen) {
-        (async () => {
-          setLoading(true);
-          await loadItems();
-        })();
-      } else {
+      if (!isOpen) {
         reset();
       }
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Description
<!--- Describe your changes in detail -->
- changed when media and files list are loaded using `useEffect` hook.
- added conditions to the load more function to prevent infinite loops

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#2403 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Fixes a bug when you send new files or media in the channel, the list does not update.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally

## Screenshots (if appropriate):

https://user-images.githubusercontent.com/6764881/189665125-63ff8526-b22d-4d77-bf88-daf8362c9389.mp4



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

