### PR TITLE
🛠  message marked as read when the message is received and the tab is not active

### DIFF
--- a/twake/frontend/src/app/views/applications/messages/messages-list.tsx
+++ b/twake/frontend/src/app/views/applications/messages/messages-list.tsx
@@ -76,7 +76,7 @@ export default ({ channelId, companyId, workspaceId }: Props) => {
   }, []);
 
   useEffect(() => {
-    if (window.reachedEnd && atBottom && messages.length > 0) {
+    if (window.reachedEnd && atBottom && messages.length > 0 && !document.hidden) {
       const seenMessages = messages.filter(message => {
         const m = getMessage(message.id || message.threadId);
         const currentUserId = User.getCurrentUserId();
@@ -94,7 +94,7 @@ export default ({ channelId, companyId, workspaceId }: Props) => {
         })
       }
     }
-  }, [messages, messages.length,  window.reachedEnd]);
+  }, [messages, messages.length,  window.reachedEnd, document.hidden]);
 
   const { highlight, cancelHighlight, reachedHighlight } = useHighlightMessage();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- added a check for the browser tab state before sending the read message request
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- #2472 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Fixes messages being marked as read when the browser tab is not active

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally

## Screenshots (if appropriate):

https://user-images.githubusercontent.com/6764881/190388621-13685427-1a8e-429d-b7f3-da0d1ec45718.mp4



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)