### PR TITLE
Added symlinks for docker log collector

### DIFF
--- a/twake/docker/twake-nginx/entrypoint.sh
+++ b/twake/docker/twake-nginx/entrypoint.sh
@@ -43,5 +43,10 @@ export PHP_UPSTREAM
 envsubst '$${NODE_HOST} $${NGINX_LISTEN}' < /etc/nginx/sites-available/site.template > /etc/nginx/sites-enabled/site
 echo "upstream php-upstream { server ${PHP_UPSTREAM}; }" > /etc/nginx/conf.d/upstream.conf
 
+# Symlink stdout and stderr to logs file for docker log collector
+# See https://github.com/nginxinc/docker-nginx/blob/456bf337ceb922a207651aa7c6077a316c3e368c/mainline/debian/Dockerfile#L99-L100
+ln -sf /dev/stdout /var/log/nginx/access.log && \
+  ln -sf /dev/stderr /var/log/nginx/error.log
+
 cron -f &
 nginx -g "daemon off;"


### PR DESCRIPTION
This should let docker show nginx logs in the container output (`docker logs` and `docker compose logs`)