### PR TITLE
🤖 Kg changes

### DIFF
--- a/Documentation/docs/internal-documentation/backend-services/knowledge-graph/README.md
+++ b/Documentation/docs/internal-documentation/backend-services/knowledge-graph/README.md
@@ -1,0 +1,39 @@
+The knowledge graph can send us event at the following endpoint:
+`POST https://api.twake.app/internal/services/knowledge-graph/v1/push`
+
+Authorized by a Token authorization header:
+`Authorization: Token {some token defined together}`
+
+And with the following data in JSON:
+
+```
+{
+  events: [KnowledgeGraphCallbackEvent, KnowledgeGraphCallbackEvent, KnowledgeGraphCallbackEvent, ...]
+}
+
+type KnowledgeGraphCallbackEvent = {
+  recipients: {
+    type: "user";
+    id: string; // KG user id which is a md5 of the email
+  }[];
+  event: {
+    type: "user_tags"; //More events will be added later
+    data: {
+      //For user_tags event only
+      tags?: {
+        value: string;
+        weight: number;
+      }[];
+    };
+  };
+};
+
+```
+
+The reply will be if everything was alright:
+
+```
+{
+  "status": "success"
+}
+```

--- a/twake/backend/node/config/default.json
+++ b/twake/backend/node/config/default.json
@@ -145,6 +145,7 @@
   },
   "knowledge-graph": {
     "endpoint": "http://host-gateway:8888",
+    "callback_token": "secret",
     "use": false,
     "forwarded_companies": []
   },
@@ -182,6 +183,7 @@
     "cron",
     "online",
     "knowledge-graph",
+    "knowledge-graph-web",
     "email-pusher"
   ]
 }

--- a/twake/backend/node/src/core/platform/services/knowledge-graph/index.ts
+++ b/twake/backend/node/src/core/platform/services/knowledge-graph/index.ts
@@ -6,7 +6,11 @@ import Company from "../../../../services/user/entities/company";
 import User from "../../../../services/user/entities/user";
 import { Channel } from "../../../../services/channels/entities";
 import { Message } from "../../../../services/messages/entities/messages";
-import { KnowledgeGraphGenericEventPayload, KnowledgeGraphEvents } from "./types";
+import {
+  KnowledgeGraphGenericEventPayload,
+  KnowledgeGraphEvents,
+  KnowledgeGraphCallbackEvent,
+} from "./types";
 import KnowledgeGraphAPIClient from "./api-client";
 import gr from "../../../../services/global-resolver";
 
@@ -55,6 +59,15 @@ export default class KnowledgeGraphService
     );
 
     return this;
+  }
+
+  /** When the KG service send us new events */
+  async onCallbackEvent(token: string, data: KnowledgeGraphCallbackEvent): Promise<void> {
+    if (token === this.getConfigurationEntry<string>("callback_token")) {
+      this.logger.info("Unimplemented: KnowledgeGraph - Callback event", data);
+    } else {
+      throw new Error("Invalid token");
+    }
   }
 
   async onCompanyCreated(data: KnowledgeGraphGenericEventPayload<Company>): Promise<void> {

--- a/twake/backend/node/src/core/platform/services/knowledge-graph/types.ts
+++ b/twake/backend/node/src/core/platform/services/knowledge-graph/types.ts
@@ -90,3 +90,20 @@ export enum KnowledgeGraphEvents {
   MESSAGE_UPSERT = "kg:message:upsert",
   USER_UPSERT = "kg:user:upsert",
 }
+
+export type KnowledgeGraphCallbackEvent = {
+  recipients: {
+    type: "user";
+    id: string; // KG user id which is a md5 of the email
+  }[];
+  event: {
+    type: "user_tags"; //More events will be added later
+    data: {
+      //For user_tags event only
+      tags?: {
+        value: string;
+        weight: number;
+      }[];
+    };
+  };
+};

--- a/twake/backend/node/src/services/general/index.ts
+++ b/twake/backend/node/src/services/general/index.ts
@@ -6,7 +6,7 @@ import { ServerConfiguration } from "./types";
 
 @Prefix("/internal/services/general/v1")
 @Consumes(["webserver"])
-export default class MessageService extends TwakeService<GeneralServiceAPI> {
+export default class GeneralService extends TwakeService<GeneralServiceAPI> {
   version = "1";
   name = "general";
   service: GeneralServiceAPI;

--- a/twake/backend/node/src/services/knowledge-graph-web/index.ts
+++ b/twake/backend/node/src/services/knowledge-graph-web/index.ts
@@ -1,0 +1,25 @@
+import { Consumes, Prefix, TwakeService } from "../../core/platform/framework";
+import WebServerAPI from "../../core/platform/services/webserver/provider";
+import web from "./web/index";
+
+@Prefix("/internal/services/knowledge-graph/v1")
+@Consumes(["webserver"])
+export default class MessageService extends TwakeService<undefined> {
+  version = "1";
+  name = "knowledge-graph";
+
+  api(): undefined {
+    return undefined;
+  }
+
+  public async doInit(): Promise<this> {
+    const fastify = this.context.getProvider<WebServerAPI>("webserver").getServer();
+
+    fastify.register((instance, _opts, next) => {
+      web(instance, { prefix: this.prefix });
+      next();
+    });
+
+    return this;
+  }
+}

--- a/twake/backend/node/src/services/knowledge-graph-web/web/index.ts
+++ b/twake/backend/node/src/services/knowledge-graph-web/web/index.ts
@@ -1,0 +1,12 @@
+import { FastifyInstance, FastifyRegisterOptions } from "fastify";
+import routes from "./routes";
+
+export default (
+  fastify: FastifyInstance,
+  options: FastifyRegisterOptions<{
+    prefix: string;
+  }>,
+): void => {
+  fastify.log.debug("Configuring /internal/services/knowledge-graph/v1 routes");
+  fastify.register(routes, options);
+};

--- a/twake/backend/node/src/services/knowledge-graph-web/web/routes.ts
+++ b/twake/backend/node/src/services/knowledge-graph-web/web/routes.ts
@@ -23,13 +23,14 @@ const routes: FastifyPluginCallback = (fastify: FastifyInstance, _, next) => {
         }
       } catch (e) {
         reply.status(500).send({
+          status: "error",
           error: "Internal server error",
           message: e.message || "Unknown error",
         });
       }
 
       reply.status(200).send({
-        message: "OK",
+        status: "success",
       });
     },
   });

--- a/twake/backend/node/src/services/knowledge-graph-web/web/routes.ts
+++ b/twake/backend/node/src/services/knowledge-graph-web/web/routes.ts
@@ -1,0 +1,40 @@
+import { FastifyInstance, FastifyPluginCallback, FastifyReply, FastifyRequest } from "fastify";
+import { KnowledgeGraphCallbackEvent } from "../../../core/platform/services/knowledge-graph/types";
+import gr from "../../global-resolver";
+
+const routes: FastifyPluginCallback = (fastify: FastifyInstance, _, next) => {
+  fastify.route({
+    method: "POST",
+    url: "/push",
+    handler: async (
+      request: FastifyRequest<{
+        Body: {
+          events: KnowledgeGraphCallbackEvent[];
+        };
+      }>,
+      reply: FastifyReply,
+    ): Promise<any> => {
+      try {
+        for (let i = 0; i < request.body.events.length; i++) {
+          await gr.platformServices.knowledgeGraph.onCallbackEvent(
+            request.headers.authorization.split(" ")[1],
+            request.body.events[i],
+          );
+        }
+      } catch (e) {
+        reply.status(500).send({
+          error: "Internal server error",
+          message: e.message || "Unknown error",
+        });
+      }
+
+      reply.status(200).send({
+        message: "OK",
+      });
+    },
+  });
+
+  next();
+};
+
+export default routes;


### PR DESCRIPTION
#2629 

We open an endpoint at:
`POST https://api.twake.app/internal/services/knowledge-graph/v1/push`

Authorised by a Token authorization header:
`Authorization: Token {some token defined together}`

And with the following data in JSON:
```
{
  events: [KnowledgeGraphCallbackEvent, KnowledgeGraphCallbackEvent, KnowledgeGraphCallbackEvent, ...]
}

type KnowledgeGraphCallbackEvent = {
  recipients: {
    type: "user";
    id: string; // KG user id which is a md5 of the email
  }[];
  event: {
    type: "user_tags"; //More events will be added later
    data: {
      //For user_tags event only
      tags?: {
        value: string;
        weight: number;
      }[];
    };
  };
};

```

The reply will be if everything was alright:
```
{
  "status": "success"
}
```