### PR TITLE
fix: `logger.warning` -> `logger.warn`

### DIFF
--- a/twake/backend/node/src/core/platform/services/search/index.ts
+++ b/twake/backend/node/src/core/platform/services/search/index.ts
@@ -37,7 +37,7 @@ export default class Search extends TwakeService<SearchServiceAPI> {
       logger.info("Loaded Mongo adapter for search.");
       this.service = new MongosearchService(this.database);
     } else {
-      logger.warning("No adapter for search was loaded.");
+      logger.warn("No adapter for search was loaded.");
       this.service = null;
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR fixes a typo in the search service that references a non-existent logger method.

## Related Issue
Fixes #2690.

## Motivation and Context
It allows twake-node to be deployed without a search service.

## How Has This Been Tested?
I've successfully deployed twake-node locally without configuring a search service.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added the Signed-off-by statement at the end of my commit message.
