### PR TITLE
📁 Fixed drive item versions not working with Cassandra

### DIFF
--- a/twake/backend/node/src/services/documents/entities/file-version.ts
+++ b/twake/backend/node/src/services/documents/entities/file-version.ts
@@ -4,7 +4,7 @@ import { Column, Entity } from "../../../core/platform/services/database/service
 export const TYPE = "drive_file_versions";
 
 @Entity(TYPE, {
-  primaryKey: [["file_id"], "id"],
+  primaryKey: [["drive_item_id"], "id"],
   type: TYPE,
 })
 export class FileVersion {
@@ -17,8 +17,8 @@ export class FileVersion {
   provider: "internal" | "drive" | string;
 
   @Type(() => String)
-  @Column("file_id", "uuid")
-  file_id: string;
+  @Column("drive_item_id", "uuid")
+  drive_item_id: string;
 
   @Column("file_metadata", "encoded_json")
   file_metadata: DriveFileMetadata;

--- a/twake/backend/node/src/services/documents/services/index.ts
+++ b/twake/backend/node/src/services/documents/services/index.ts
@@ -120,7 +120,7 @@ export class DocumentsService {
       : (
           await this.fileVersionRepository.find(
             {
-              file_id: entity.id,
+              drive_item_id: entity.id,
             },
             {},
             context,
@@ -236,7 +236,7 @@ export class DocumentsService {
       );
 
       await this.repository.save(driveItem);
-      driveItemVersion.file_id = driveItem.id;
+      driveItemVersion.drive_item_id = driveItem.id;
 
       await this.fileVersionRepository.save(driveItemVersion);
       driveItem.last_version_cache = driveItemVersion;
@@ -463,7 +463,7 @@ export class DocumentsService {
           //Delete the version and stored file
           const itemVersions = await this.fileVersionRepository.find(
             {
-              file_id: item.id,
+              drive_item_id: item.id,
             },
             {},
             context,

--- a/twake/backend/node/src/services/documents/utils.ts
+++ b/twake/backend/node/src/services/documents/utils.ts
@@ -100,7 +100,7 @@ export const getDefaultDriveItemVersion = (
     creator_id: version.creator_id || context.user?.id,
     data: version.data || {},
     date_added: version.date_added || new Date().getTime(),
-    file_id: version.file_id || "",
+    drive_item_id: version.drive_item_id || "",
     file_metadata: version.file_metadata || {},
     file_size: version.file_size || 0,
     filename: version.filename || "",

--- a/twake/backend/node/src/services/documents/web/schemas.ts
+++ b/twake/backend/node/src/services/documents/web/schemas.ts
@@ -3,7 +3,7 @@ const fileVersionSchema = {
   properties: {
     id: { type: "string" },
     provider: { type: "string" },
-    file_id: { type: "string" },
+    drive_item_id: { type: "string" },
     file_metadata: {
       type: "object",
       properties: {

--- a/twake/frontend/src/app/features/drive/hooks/use-drive-upload.tsx
+++ b/twake/frontend/src/app/features/drive/hooks/use-drive-upload.tsx
@@ -21,7 +21,7 @@ export const useDriveUpload = () => {
         callback: async (file, context) => {
           if (file) {
             const version = {
-              file_id: context.id,
+              drive_item_id: context.id,
               provider: 'internal',
               application_id: '',
               file_metadata: {

--- a/twake/frontend/src/app/features/drive/types.ts
+++ b/twake/frontend/src/app/features/drive/types.ts
@@ -55,7 +55,7 @@ export type DriveItemVersion = {
 
   //The file itself, using the existing new node "file" entity
   provider: string | 'drive' | 'internal'; //Equivalent to "source" in twake/backend/node/src/services/messages/entities/message-files.ts
-  file_id: string;
+  drive_item_id: string;
   file_metadata: FileMetadata; //New field
 
   date_added: number;

--- a/twake/frontend/src/app/views/applications/drive/modals/versions/index.tsx
+++ b/twake/frontend/src/app/views/applications/drive/modals/versions/index.tsx
@@ -103,7 +103,7 @@ const VersionModalContent = ({ id }: { id: string }) => {
               <BaseSmall>{formatBytes(version.file_metadata.size || 0)}</BaseSmall>
             </div>
             <div className="shrink-0 ml-4">
-              <Button theme="outline" onClick={() => download(id, version.file_id)}>
+              <Button theme="outline" onClick={() => download(id, version.drive_item_id)}>
                 Download
               </Button>
             </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- changed the order of the primary key fields to fix the drive item versions fetching when using the Cassandra database.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#2714

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- fixes versions not showing up in the drive.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

