### PR TITLE
📁 Fix copy public link #2709

### DIFF
--- a/twake/frontend/src/app/features/global/utils/CopyClipboard.ts
+++ b/twake/frontend/src/app/features/global/utils/CopyClipboard.ts
@@ -1,8 +1,13 @@
-export function copyToClipboard(url: string): void {
-    const el = document.createElement('textarea');
-    el.value = url;
-    document.body.appendChild(el);
-    el.select();
-    document.execCommand('copy');
-    document.body.removeChild(el);
-}
+export async function copyToClipboard(url: string): Promise<void> {
+    try {
+      await navigator.clipboard.writeText(url);
+    } catch (err) {
+      const el = document.createElement('textarea');
+      el.value = url;
+      document.body.appendChild(el);
+      el.select();
+      document.execCommand('copy');
+      document.body.removeChild(el);
+    }
+  }
+  


### PR DESCRIPTION
## Description
File -> Access management -> Copy public link to the clipboard, not working, nothing in clipboard when testing in staging.

## Motivation and Context
The old document.execCommand('copy') method is used to execute a "copy" command on the current document. This method has been implemented in various web browsers, but the exact behavior and implementation may vary between different browsers. In some cases, the document.execCommand('copy') method may not work as expected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
