### PR TITLE
added new drive migration banner to canary

### DIFF
--- a/twake/frontend/public/index.html
+++ b/twake/frontend/public/index.html
@@ -143,6 +143,7 @@
         const canaryTag = document.createElement("div");
         canaryTag.id = "canary_tag";
         document.body.appendChild(canaryTag);
+        window.canary = true;
       }
     </script>
   </body>

--- a/twake/frontend/src/app/views/applications/drive/browser.tsx
+++ b/twake/frontend/src/app/views/applications/drive/browser.tsx
@@ -1,6 +1,6 @@
 import { ChevronDownIcon } from '@heroicons/react/outline';
 import { Button } from 'app/atoms/button/button';
-import { Base, BaseSmall, Subtitle, Title } from 'app/atoms/text';
+import { Base, BaseSmall, Info, Subtitle, Title } from 'app/atoms/text';
 import Menu from 'app/components/menus/menu';
 import { getFilesTree } from 'app/components/uploads/file-tree-utils';
 import UploadZone from 'app/components/uploads/upload-zone';
@@ -123,6 +123,15 @@ export default ({
           (loading && !children?.length ? 'opacity-50 ' : '')
         }
       >
+        {(window as any).canary && (
+          <div className="bg-linear-purple w-full hidden sm:block px-4 py-2">
+            <Info className=" !text-white">
+              This is the new Drive, your documents are not migrated here yet, you can exit canary
+              to see all your previous documents. Documents added here will not be visible yet on
+              production but will be kept after the final migration.
+            </Info>
+          </div>
+        )}
         <div className="flex flex-row shrink-0 items-center">
           <HeaderPath path={path || []} inTrash={inTrash} setParentId={setParentId} />
           <div className="grow" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
when in canary it shows a message in the new drive to inform the user about the old and new drive.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#2757 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
helps with drive migration

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
locally

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/6764881/221454277-2ef949cd-f086-41bc-b107-1c13f7fba1c4.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
