### PR TITLE
Fix twake.app url in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Twake offers all the features for collaboration :
 - Video call and conferencing
 - Real time document collaboration
 
-<a href="https://twakeapp.com"><img width=800 src="https://github.com/linagora/Twake/raw/main/twake.png"/></a>
+<a href="https://twake.app"><img width=800 src="https://github.com/linagora/Twake/raw/main/twake.png"/></a>
 
 ## Demo
 


### PR DESCRIPTION
The readme had a wrong twakeapp.com url which was redirecting to some weird slots/ads site.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixed only the link in the readme. 

## Related Issue
No related issue. Feel free to close this PR if you wish - but this is also meant as a warning as there are a lot of other twakeapp.com mentions in the codebase.
